### PR TITLE
Travis: remove linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
 cache: yarn
 script:
 - yarn test
-- yarn lint
 - yarn coveralls
 - yarn dist
 


### PR DESCRIPTION
Linter is not executed explicitely by travis since it is farther
included in a more generic `yarn dist` target.

The `yarn test` remains since it is required to collect coveralls data.