### PR TITLE
Fix "main" JS entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/kubevirt/web-ui-components",
-  "main": "dist/index.js",
+  "main": "dist/js/index.js",
   "files": [
     "/dist"
   ],


### PR DESCRIPTION
With this fix, the consuming project can simply
```
  import ... from "kubevirt-web-ui-components"
```
indested of
```
  import ... from "kubevirt-web-ui-components/dist/js"
```