### PR TITLE
Turn off Jekyll when served via GitHub Pages

### DIFF
--- a/tools/travis/tasks/exportCosmos.js
+++ b/tools/travis/tasks/exportCosmos.js
@@ -16,6 +16,8 @@ async function exportCosmos() {
     await execShell('yarn cosmos:export');
     // add build-info.txt to provide additional build details
     fs.writeFileSync(`${paths.cosmosExport}/build-info.txt`, getBuildInfo());
+    // add .nojekyll file to turn off Jekyll when served via GitHub Pages
+    fs.writeFileSync(`${paths.cosmosExport}/.nojekyll`, '');
     return true;
   } catch (error) {
     return false;


### PR DESCRIPTION
This fixes the problem of [GitHub Pages not serving files that start with an underscore](https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/).