### PR TITLE
Use relative Cosmos publicUrl

### DIFF
--- a/config/cosmos.config.js
+++ b/config/cosmos.config.js
@@ -14,8 +14,11 @@ module.exports = {
   // path to Cosmos proxies
   proxiesPath: `${paths.src}/cosmos/proxies.js`,
 
-  // webpack server settings
+  // webpack configuration
   webpackConfigPath: `${paths.config}/cosmos.webpack.config.js`,
+  publicUrl: './',
+
+  // dev server settings
   watchDirs: [paths.src],
   port: 9000,
 


### PR DESCRIPTION
The current default value of `publicUrl` is [`'/'`](https://github.com/react-cosmos/react-cosmos/blob/master/packages/react-cosmos-config/src/index.js#L38).

While this works for URLs like http://localhost:9000/, it doesn't work for URLs like https://kubevirt.io/web-ui-components/.

This PR sets `publicUrl` to `'./'` which should work for both URLs mentioned above ([see here for details](https://github.com/react-cosmos/react-cosmos/issues/777)).