### PR TITLE
NewVmWizard: fix fixture

### DIFF
--- a/src/components/Wizard/NewVmWizard/fixtures/NewVmWizard.fixture.js
+++ b/src/components/Wizard/NewVmWizard/fixtures/NewVmWizard.fixture.js
@@ -1,5 +1,5 @@
 import { NewVmWizard } from '..';
-import { templates } from '../../../../constants';
+import { templates, networkConfigs } from '../../../../constants';
 import { ProcessedTemplatesModel } from '../../../../models';
 
 export const namespaces = [
@@ -108,6 +108,7 @@ export default {
     namespaces,
     storageClasses,
     persistentVolumeClaims,
+    networkConfigs,
     k8sCreate,
     units,
   },


### PR DESCRIPTION
 I am not sure if this component is still needed, because it is not used in kubevirt/we-ui? Maybe we should deprecate it.