### PR TITLE
Fix VmConsoles: provide VncConsole type

### DIFF
--- a/src/components/VmConsoles/VmConsoles.js
+++ b/src/components/VmConsoles/VmConsoles.js
@@ -65,7 +65,7 @@ export const VmConsoles = ({
     <div className="co-m-pane__body">
       <AccessConsoles preselectedType={VNC_CONSOLE_TYPE}>
         <SerialConsoleConnector type={SERIAL_CONSOLE_TYPE} WSFactory={WSFactory} {...serialConDetails} />
-        <VncConsole {...vncConDetails} />
+        <VncConsole type={VNC_CONSOLE_TYPE} {...vncConDetails} />
       </AccessConsoles>
     </div>
   );


### PR DESCRIPTION
This is a hotfix which will be handled in patternfly-react as well.