### PR TITLE
Add DesktopViewer to VmConsoles

### DIFF
--- a/sass/components/_VmConsoles.scss
+++ b/sass/components/_VmConsoles.scss
@@ -3,6 +3,6 @@
   margin-top: -14px !important;
 }
 
-.vm-consoles-no-rdp .expand-collapse-pf-link-container {
+.kubevirt-vm-consoles__rdp .expand-collapse-pf-link-container {
   float: right;
 }

--- a/sass/components/_VmConsoles.scss
+++ b/sass/components/_VmConsoles.scss
@@ -2,3 +2,7 @@
   padding-bottom: 12px !important;
   margin-top: -14px !important;
 }
+
+.vm-consoles-no-rdp .expand-collapse-pf-link-container {
+  float: right;
+}

--- a/src/components/VmConsoles/VmConsoles.js
+++ b/src/components/VmConsoles/VmConsoles.js
@@ -9,6 +9,7 @@ import { Button, ExpandCollapse } from 'patternfly-react';
 import { isVmiRunning, isVmStarting } from '../VmStatus';
 import SerialConsoleConnector from './SerialConsoleConnector';
 import { isWindows } from '../../utils';
+import { DEFAULT_RDP_PORT, TEMPLATE_VM_NAME_LABEL } from '../../constants';
 
 const { VNC_CONSOLE_TYPE, SERIAL_CONSOLE_TYPE } = AccessConsoles.constants;
 
@@ -59,18 +60,18 @@ const RdpServiceNotConfigured = ({ vm }) => (
           For better experience accessing Windows console, it is recommended to use the RDP. To do so, create a service:
           <ul>
             <li>
-              exposing the <b>3389/tcp</b> port of the virtual machine
+              exposing the <b>{DEFAULT_RDP_PORT}/tcp</b> port of the virtual machine
             </li>
             <li>
-              using selector: <b>vm.cnv.io/name: {vm.metadata.name}</b>
+              using selector: <b>{TEMPLATE_VM_NAME_LABEL}: {vm.metadata.name}</b>
             </li>
             <li>
               Example: virtctl expose virtualmachine {vm.metadata.name} --name {vm.metadata.name}
-              -rdp --port [UNIQUE_PORT] --target-port 3389 --type NodePort
+              -rdp --port [UNIQUE_PORT] --target-port {DEFAULT_RDP_PORT} --type NodePort
             </li>
           </ul>
           Make sure, the VM object has <b>spec.template.metadata.labels</b> set to{' '}
-          <b>vm.cnv.io/name: {vm.metadata.name}</b>
+          <b>{TEMPLATE_VM_NAME_LABEL}: {vm.metadata.name}</b>
         </span>
       </div>
     </ExpandCollapse>

--- a/src/components/VmConsoles/VmConsoles.js
+++ b/src/components/VmConsoles/VmConsoles.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { get } from 'lodash';
+
 import { AccessConsoles, VncConsole, DesktopViewer } from '@patternfly/react-console';
 import { Button } from 'patternfly-react';
 
@@ -46,9 +48,9 @@ export const VmConsoles = ({
   vm,
   vmi,
   onStartVm,
-  getVncConnectionDetails,
-  getSerialConsoleConnectionDetails,
-  getRdpConnectionDetails,
+  vnc,
+  serial,
+  rdp,
   WSFactory,
   LoadingComponent,
 }) => {
@@ -60,15 +62,12 @@ export const VmConsoles = ({
     );
   }
   // TODO: increase patternfly/react-console dependency version
-  const vncConDetails = getVncConnectionDetails(vmi);
-  const serialConDetails = getSerialConsoleConnectionDetails(vmi);
-  const rdpConDetails = getRdpConnectionDetails(vmi);
   return (
     <div className="co-m-pane__body">
       <AccessConsoles preselectedType={VNC_CONSOLE_TYPE}>
         <SerialConsoleConnector type={SERIAL_CONSOLE_TYPE} WSFactory={WSFactory} {...serialConDetails} />
-        <VncConsole {...vncConDetails} />
-        <DesktopViewer spice={serialConDetails.manual} vnc={vncConDetails.manual} rdp={rdpConDetails.manual} />
+        <VncConsole {...vnc} />
+        <DesktopViewer vnc={get(vnc.manual)} rdp={rdp.manual} />
       </AccessConsoles>
     </div>
   );
@@ -77,8 +76,9 @@ VmConsoles.propTypes = {
   vm: PropTypes.object.isRequired,
   vmi: PropTypes.object,
 
-  getVncConnectionDetails: PropTypes.func.isRequired,
-  getSerialConsoleConnectionDetails: PropTypes.func.isRequired,
+  vnc: PropTypes.object,
+  serial: PropTypes.object,
+  rdp: PropTypes.object,
   onStartVm: PropTypes.func.isRequired,
 
   LoadingComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
@@ -86,4 +86,8 @@ VmConsoles.propTypes = {
 };
 VmConsoles.defaultProps = {
   vmi: undefined,
+
+  vnc: undefined,
+  serial: undefined,
+  rdp: undefined,
 };

--- a/src/components/VmConsoles/VmConsoles.js
+++ b/src/components/VmConsoles/VmConsoles.js
@@ -4,10 +4,11 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
 import { AccessConsoles, VncConsole, DesktopViewer } from '@patternfly/react-console';
-import { Button } from 'patternfly-react';
+import { Button, ExpandCollapse } from 'patternfly-react';
 
 import { isVmiRunning, isVmStarting } from '../VmStatus';
 import SerialConsoleConnector from './SerialConsoleConnector';
+import { isWindows } from '../../utils';
 
 const { VNC_CONSOLE_TYPE, SERIAL_CONSOLE_TYPE } = AccessConsoles.constants;
 
@@ -41,6 +42,39 @@ VmIsStarting.propTypes = {
   LoadingComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
 };
 
+const RdpServiceNotConfigured = ({ vm }) => (
+  <div className="vm-consoles-no-rdp">
+    <ExpandCollapse
+      bordered={false}
+      align={ExpandCollapse.ALIGN_CENTER}
+      textCollapsed="No RDP Service found"
+      textExpanded="No RDP Service found"
+    >
+      <div className="vm-consoles-no-rdp-content">
+        <p>This is a Windows virtual machine but no Service for the RDP (Remote Desktop Protocol) can be found.</p>
+        <p>For better experience accessing Windows console, it is recommended to use the RDP.</p>
+        <p>
+          To do so, create a service:
+          <ul>
+            <li>
+              exposing the <b>3389/tcp</b> port of the virtual machine
+            </li>
+            <li>
+              using selector: <b>vm.cnv.io/name: {vm.metadata.name}</b>
+            </li>
+          </ul>
+          Make sure, the VM object has <b>spec.template.metadata.labels</b> set to{' '}
+          <b>vm.cnv.io/name: {vm.metadata.name}</b>
+        </p>
+      </div>
+    </ExpandCollapse>
+  </div>
+);
+
+RdpServiceNotConfigured.propTypes = {
+  vm: PropTypes.object.isRequired,
+};
+
 /**
  * Actual component for consoles.
  */
@@ -52,13 +86,22 @@ export const VmConsoles = ({ vm, vmi, onStartVm, vnc, serial, rdp, WSFactory, Lo
       <VmIsDown vm={vm} onStartVm={onStartVm} />
     );
   }
-  // TODO: increase patternfly/react-console dependency version
+
+  let infoMessage;
+  const vncManual = get({ vnc }, 'vnc.manual');
+  const rdpManual = get({ rdp }, 'rdp.manual');
+
+  if (!rdpManual && isWindows(vm)) {
+    infoMessage = <RdpServiceNotConfigured vm={vm} />;
+  }
+
   return (
     <div className="co-m-pane__body">
+      {infoMessage}
       <AccessConsoles preselectedType={VNC_CONSOLE_TYPE}>
         <SerialConsoleConnector type={SERIAL_CONSOLE_TYPE} WSFactory={WSFactory} {...serial} />
         <VncConsole {...vnc} />
-        <DesktopViewer vnc={get(vnc, 'manual')} rdp={get(rdp, 'manual')} />
+        {(vncManual || rdpManual) && <DesktopViewer vnc={vncManual} rdp={rdpManual} />}
       </AccessConsoles>
     </div>
   );

--- a/src/components/VmConsoles/VmConsoles.js
+++ b/src/components/VmConsoles/VmConsoles.js
@@ -51,10 +51,12 @@ const RdpServiceNotConfigured = ({ vm }) => (
       textExpanded="No RDP Service found"
     >
       <div className="vm-consoles-no-rdp-content">
-        <p>This is a Windows virtual machine but no Service for the RDP (Remote Desktop Protocol) can be found.</p>
-        <p>For better experience accessing Windows console, it is recommended to use the RDP.</p>
-        <p>
-          To do so, create a service:
+        <span>
+          This is a Windows virtual machine but no Service for the RDP (Remote Desktop Protocol) can be found.
+        </span>
+        <br />
+        <span>
+          For better experience accessing Windows console, it is recommended to use the RDP. To do so, create a service:
           <ul>
             <li>
               exposing the <b>3389/tcp</b> port of the virtual machine
@@ -69,7 +71,7 @@ const RdpServiceNotConfigured = ({ vm }) => (
           </ul>
           Make sure, the VM object has <b>spec.template.metadata.labels</b> set to{' '}
           <b>vm.cnv.io/name: {vm.metadata.name}</b>
-        </p>
+        </span>
       </div>
     </ExpandCollapse>
   </div>

--- a/src/components/VmConsoles/VmConsoles.js
+++ b/src/components/VmConsoles/VmConsoles.js
@@ -44,16 +44,7 @@ VmIsStarting.propTypes = {
 /**
  * Actual component for consoles.
  */
-export const VmConsoles = ({
-  vm,
-  vmi,
-  onStartVm,
-  vnc,
-  serial,
-  rdp,
-  WSFactory,
-  LoadingComponent,
-}) => {
+export const VmConsoles = ({ vm, vmi, onStartVm, vnc, serial, rdp, WSFactory, LoadingComponent }) => {
   if (!isVmiRunning(vmi)) {
     return isVmStarting(vm, vmi) ? (
       <VmIsStarting LoadingComponent={LoadingComponent} />
@@ -65,9 +56,9 @@ export const VmConsoles = ({
   return (
     <div className="co-m-pane__body">
       <AccessConsoles preselectedType={VNC_CONSOLE_TYPE}>
-        <SerialConsoleConnector type={SERIAL_CONSOLE_TYPE} WSFactory={WSFactory} {...serialConDetails} />
+        <SerialConsoleConnector type={SERIAL_CONSOLE_TYPE} WSFactory={WSFactory} {...serial} />
         <VncConsole {...vnc} />
-        <DesktopViewer vnc={get(vnc.manual)} rdp={rdp.manual} />
+        <DesktopViewer vnc={get(vnc, 'manual')} rdp={get(rdp, 'manual')} />
       </AccessConsoles>
     </div>
   );

--- a/src/components/VmConsoles/VmConsoles.js
+++ b/src/components/VmConsoles/VmConsoles.js
@@ -22,7 +22,9 @@ const VmIsDown = ({ vm, onStartVm }) => {
 
   return (
     <div className="co-m-pane__body">
-      <div className="vm-consoles-loading">This Virtual Machine is down. Please {action} it to access its console.</div>
+      <div className="kubevirt-vm-consoles__loading">
+        This Virtual Machine is down. Please {action} it to access its console.
+      </div>
     </div>
   );
 };
@@ -33,7 +35,7 @@ VmIsDown.propTypes = {
 
 const VmIsStarting = ({ LoadingComponent }) => (
   <div className="co-m-pane__body">
-    <div className="vm-consoles-loading">
+    <div className="kubevirt-vm-consoles__loading">
       <LoadingComponent />
       This Virtual Machine is still starting up. The console will be available soon.
     </div>
@@ -44,14 +46,14 @@ VmIsStarting.propTypes = {
 };
 
 const RdpServiceNotConfigured = ({ vm }) => (
-  <div className="vm-consoles-no-rdp">
+  <div className="kubevirt-vm-consoles__rdp">
     <ExpandCollapse
       bordered={false}
       align={ExpandCollapse.ALIGN_CENTER}
       textCollapsed="No RDP Service found"
       textExpanded="No RDP Service found"
     >
-      <div className="vm-consoles-no-rdp-content">
+      <div className="kubevirt-vm-consoles__rdp-content">
         <span>
           This is a Windows virtual machine but no Service for the RDP (Remote Desktop Protocol) can be found.
         </span>
@@ -60,10 +62,18 @@ const RdpServiceNotConfigured = ({ vm }) => (
           For better experience accessing Windows console, it is recommended to use the RDP. To do so, create a service:
           <ul>
             <li>
-              exposing the <b>{DEFAULT_RDP_PORT}/tcp</b> port of the virtual machine
+              exposing the{' '}
+              <b>
+                {DEFAULT_RDP_PORT}
+                /tcp
+              </b>{' '}
+              port of the virtual machine
             </li>
             <li>
-              using selector: <b>{TEMPLATE_VM_NAME_LABEL}: {vm.metadata.name}</b>
+              using selector:{' '}
+              <b>
+                {TEMPLATE_VM_NAME_LABEL}: {vm.metadata.name}
+              </b>
             </li>
             <li>
               Example: virtctl expose virtualmachine {vm.metadata.name} --name {vm.metadata.name}
@@ -71,7 +81,9 @@ const RdpServiceNotConfigured = ({ vm }) => (
             </li>
           </ul>
           Make sure, the VM object has <b>spec.template.metadata.labels</b> set to{' '}
-          <b>{TEMPLATE_VM_NAME_LABEL}: {vm.metadata.name}</b>
+          <b>
+            {TEMPLATE_VM_NAME_LABEL}: {vm.metadata.name}
+          </b>
         </span>
       </div>
     </ExpandCollapse>

--- a/src/components/VmConsoles/VmConsoles.js
+++ b/src/components/VmConsoles/VmConsoles.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { AccessConsoles, VncConsole } from '@patternfly/react-console';
+import { AccessConsoles, VncConsole, DesktopViewer } from '@patternfly/react-console';
 import { Button } from 'patternfly-react';
 
 import { isVmiRunning, isVmStarting } from '../VmStatus';
@@ -48,6 +48,7 @@ export const VmConsoles = ({
   onStartVm,
   getVncConnectionDetails,
   getSerialConsoleConnectionDetails,
+  getRdpConnectionDetails,
   WSFactory,
   LoadingComponent,
 }) => {
@@ -58,14 +59,16 @@ export const VmConsoles = ({
       <VmIsDown vm={vm} onStartVm={onStartVm} />
     );
   }
-
+  // TODO: increase patternfly/react-console dependency version
   const vncConDetails = getVncConnectionDetails(vmi);
   const serialConDetails = getSerialConsoleConnectionDetails(vmi);
+  const rdpConDetails = getRdpConnectionDetails(vmi);
   return (
     <div className="co-m-pane__body">
       <AccessConsoles preselectedType={VNC_CONSOLE_TYPE}>
         <SerialConsoleConnector type={SERIAL_CONSOLE_TYPE} WSFactory={WSFactory} {...serialConDetails} />
-        <VncConsole type={VNC_CONSOLE_TYPE} {...vncConDetails} />
+        <VncConsole {...vncConDetails} />
+        <DesktopViewer spice={serialConDetails.manual} vnc={vncConDetails.manual} rdp={rdpConDetails.manual} />
       </AccessConsoles>
     </div>
   );

--- a/src/components/VmConsoles/VmConsoles.js
+++ b/src/components/VmConsoles/VmConsoles.js
@@ -62,6 +62,10 @@ const RdpServiceNotConfigured = ({ vm }) => (
             <li>
               using selector: <b>vm.cnv.io/name: {vm.metadata.name}</b>
             </li>
+            <li>
+              Example: virtctl expose virtualmachine {vm.metadata.name} --name {vm.metadata.name}
+              -rdp --port [UNIQUE_PORT] --target-port 3389 --type NodePort
+            </li>
           </ul>
           Make sure, the VM object has <b>spec.template.metadata.labels</b> set to{' '}
           <b>vm.cnv.io/name: {vm.metadata.name}</b>

--- a/src/components/VmConsoles/fixtures/VmConsoles.fixture.js
+++ b/src/components/VmConsoles/fixtures/VmConsoles.fixture.js
@@ -47,6 +47,7 @@ export const downVmProps = {
 
   getVncConnectionDetails: helpers.noop,
   getSerialConsoleConnectionDetails: helpers.noop,
+  getRdpConnectionDetails: helpers.noop,
   onStartVm: helpers.noop,
   WSFactory: helpers.noop,
   LoadingComponent,
@@ -58,6 +59,7 @@ export const startingVmProps = {
 
   getVncConnectionDetails: helpers.noop,
   getSerialConsoleConnectionDetails: helpers.noop,
+  getRdpConnectionDetails: helpers.noop,
   onStartVm: helpers.noop,
   WSFactory: helpers.noop,
   LoadingComponent,

--- a/src/components/VmConsoles/tests/VmConsoles.test.js
+++ b/src/components/VmConsoles/tests/VmConsoles.test.js
@@ -43,6 +43,7 @@ describe('<VmConsoles />', () => {
     const rdp = {
       manual: {
         address: 'resp.address.com',
+        port: 3389,
       },
     };
 

--- a/src/components/VmConsoles/tests/VmConsoles.test.js
+++ b/src/components/VmConsoles/tests/VmConsoles.test.js
@@ -14,49 +14,39 @@ describe('<VmConsoles />', () => {
     expect(component).toMatchSnapshot();
   });
   it('renders correctly for a running VM', () => {
-    const getVncConnectionDetails = jest.fn(vmi => ({
+    const vnc = {
+      vmi: runningVmProps.vmi,
       encrypt: true,
       host: 'my.hostname.com',
       port: '443',
-      path: `path/to/${vmi.metadata.name}/vnc`,
+      path: `path/to/vmname/vnc`,
 
       manual: {
         address: 'vnc.address.com',
         port: 1234,
         tlsPort: 1235,
       },
-    }));
+    };
 
-    const getSerialConsoleConnectionDetails = jest.fn(vmi => ({
-      vmi,
+    const serial = {
+      vmi: runningVmProps.vmi,
       host: 'my.hostname.com',
-      path: `path/to/${vmi.metadata.name}/console`,
+      path: `path/to/vmname/console`,
 
       manual: {
         address: 'serial.address.com',
         port: 1236,
         tlsPort: 1237,
       },
-    }));
+    };
 
-    const getRdpConnectionDetails = jest.fn(vmi => ({
+    const rdp = {
       manual: {
         address: 'resp.address.com',
       },
-    }));
+    };
 
-    const component = render(
-      <VmConsoles
-        getVncConnectionDetails={getVncConnectionDetails}
-        getSerialConsoleConnectionDetails={getSerialConsoleConnectionDetails}
-        getRdpConnectionDetails={getRdpConnectionDetails}
-        {...runningVmProps}
-      />
-    );
-    expect(getVncConnectionDetails).toHaveBeenCalledTimes(1);
-    expect(getSerialConsoleConnectionDetails).toHaveBeenCalledTimes(1);
-    expect(getRdpConnectionDetails).toHaveBeenCalledTimes(1);
-
+    const component = render(<VmConsoles vnc={vnc} serial={serial} rdp={rdp} {...runningVmProps} />);
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/VmConsoles/tests/VmConsoles.test.js
+++ b/src/components/VmConsoles/tests/VmConsoles.test.js
@@ -19,23 +19,43 @@ describe('<VmConsoles />', () => {
       host: 'my.hostname.com',
       port: '443',
       path: `path/to/${vmi.metadata.name}/vnc`,
+
+      manual: {
+        address: 'vnc.address.com',
+        port: 1234,
+        tlsPort: 1235,
+      },
     }));
 
     const getSerialConsoleConnectionDetails = jest.fn(vmi => ({
       vmi,
       host: 'my.hostname.com',
       path: `path/to/${vmi.metadata.name}/console`,
+
+      manual: {
+        address: 'serial.address.com',
+        port: 1236,
+        tlsPort: 1237,
+      },
+    }));
+
+    const getRdpConnectionDetails = jest.fn(vmi => ({
+      manual: {
+        address: 'resp.address.com',
+      },
     }));
 
     const component = render(
       <VmConsoles
         getVncConnectionDetails={getVncConnectionDetails}
         getSerialConsoleConnectionDetails={getSerialConsoleConnectionDetails}
+        getRdpConnectionDetails={getRdpConnectionDetails}
         {...runningVmProps}
       />
     );
     expect(getVncConnectionDetails).toHaveBeenCalledTimes(1);
     expect(getSerialConsoleConnectionDetails).toHaveBeenCalledTimes(1);
+    expect(getRdpConnectionDetails).toHaveBeenCalledTimes(1);
 
     expect(component).toMatchSnapshot();
   });

--- a/src/components/VmConsoles/tests/__snapshots__/VmConsoles.test.js.snap
+++ b/src/components/VmConsoles/tests/__snapshots__/VmConsoles.test.js.snap
@@ -5,7 +5,7 @@ exports[`<VmConsoles /> renders correctly for a down VM 1`] = `
   class="co-m-pane__body"
 >
   <div
-    class="vm-consoles-loading"
+    class="kubevirt-vm-consoles__loading"
   >
     This Virtual Machine is down. Please 
     <button
@@ -147,7 +147,7 @@ exports[`<VmConsoles /> renders correctly for a starting VM 1`] = `
   class="co-m-pane__body"
 >
   <div
-    class="vm-consoles-loading"
+    class="kubevirt-vm-consoles__loading"
   >
     <div
       class="dummy-loading-component"

--- a/src/components/VmConsoles/tests/__snapshots__/VmConsoles.test.js.snap
+++ b/src/components/VmConsoles/tests/__snapshots__/VmConsoles.test.js.snap
@@ -80,6 +80,18 @@ exports[`<VmConsoles /> renders correctly for a running VM 1`] = `
                   Serial Console
                 </a>
               </li>
+              <li
+                class=""
+                role="presentation"
+              >
+                <a
+                  href="#"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  Desktop Viewer
+                </a>
+              </li>
             </ul>
           </div>
           <label

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -30,6 +30,7 @@ export const TEMPLATE_TYPE_LABEL = 'template.cnv.io/type';
 export const TEMPLATE_TYPE_VM = 'vm';
 export const TEMPLATE_TYPE_BASE = 'base';
 export const TEMPLATE_WORKLOAD_LABEL = 'workload.template.cnv.io';
+export const TEMPLATE_VM_NAME_LABEL = 'vm.cnv.io/name'; // TODO: add to Create VM Dialog to vm.spec.template.,etadata.labels[TEMPLATE_VM_NAME_LABEL]: my-vm-name
 
 export const VIRTIO_BUS = 'virtio';
 
@@ -39,6 +40,8 @@ export const BOOT_ORDER_SECOND = 2;
 export const VALIDATION_ERROR_TYPE = 'error';
 export const VALIDATION_WARNING_TYPE = 'warning';
 export const VALIDATION_INFO_TYPE = 'info';
+
+export const OS_WINDOWS_PREFIX = 'win';
 
 export const VM_STATUS_OFF = 'VM_STATUS_OFF';
 export const VM_STATUS_RUNNING = 'VM_STATUS_RUNNING';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -30,7 +30,7 @@ export const TEMPLATE_TYPE_LABEL = 'template.cnv.io/type';
 export const TEMPLATE_TYPE_VM = 'vm';
 export const TEMPLATE_TYPE_BASE = 'base';
 export const TEMPLATE_WORKLOAD_LABEL = 'workload.template.cnv.io';
-export const TEMPLATE_VM_NAME_LABEL = 'vm.cnv.io/name'; // TODO: add to Create VM Dialog to vm.spec.template.,etadata.labels[TEMPLATE_VM_NAME_LABEL]: my-vm-name
+export const TEMPLATE_VM_NAME_LABEL = 'vm.cnv.io/name';
 
 export const VIRTIO_BUS = 'virtio';
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -62,3 +62,5 @@ export const VM_STATUS_TO_TEXT = {
   [VM_STATUS_OFF]: 'Off',
   [VM_STATUS_OTHER]: 'Other',
 };
+
+export const DEFAULT_RDP_PORT = 3389;

--- a/src/k8s/request.js
+++ b/src/k8s/request.js
@@ -25,6 +25,7 @@ import {
   TEMPLATE_TYPE_VM,
   ANNOTATION_CLONE_REQUEST,
   LABEL_CLONE_APP,
+  TEMPLATE_VM_NAME_LABEL,
 } from '../constants';
 import {
   NAMESPACE_KEY,
@@ -217,6 +218,7 @@ const addMetadata = (vm, template, getSetting) => {
   addLabel(vm, `${TEMPLATE_WORKLOAD_LABEL}/${workload}`, 'true');
 
   addLabel(vm, ANNOTATION_USED_TEMPLATE, `${template.metadata.namespace}_${template.metadata.name}`);
+  addTemplateLabel(vm, TEMPLATE_VM_NAME_LABEL, vm.metadata.name); // for pairing service-vm (like for RDP)
 };
 
 const modifyVmObject = (vm, template, getSetting, networks, storages) => {
@@ -426,6 +428,22 @@ const getLabels = vm => {
   return vm.metadata.labels;
 };
 
+const getTemplateLabels = vm => {
+  if (!vm.spec) {
+    vm.spec = {};
+  }
+  if (!vm.spec.template) {
+    vm.spec.template = {};
+  }
+  if (!vm.spec.template.metadata) {
+    vm.spec.template.metadata = {};
+  }
+  if (!vm.spec.template.metadata.labels) {
+    vm.spec.template.metadata.labels = {};
+  }
+  return vm.spec.template.metadata.labels;
+};
+
 const addDisk = (vm, defaultDisk, storage, getSetting) => {
   const diskSpec = {
     ...(storage.templateStorage ? storage.templateStorage.disk : defaultDisk),
@@ -576,6 +594,11 @@ const addAnnotation = (vm, key, value) => {
 
 const addLabel = (vm, key, value) => {
   const labels = getLabels(vm);
+  labels[key] = value;
+};
+
+const addTemplateLabel = (vm, key, value) => {
+  const labels = getTemplateLabels(vm);
   labels[key] = value;
 };
 

--- a/src/utils/selectors.js
+++ b/src/utils/selectors.js
@@ -5,6 +5,7 @@ import {
   TEMPLATE_FLAVOR_LABEL,
   TEMPLATE_OS_LABEL,
   TEMPLATE_WORKLOAD_LABEL,
+  OS_WINDOWS_PREFIX,
 } from '../constants';
 
 export const getName = value => get(value, 'metadata.name');
@@ -62,6 +63,7 @@ export const getLabelValue = (vm, label) => {
   return labels[labelKey];
 };
 
+export const isWindows = vm => (getOperatingSystem(vm) || '').startsWith(OS_WINDOWS_PREFIX);
 export const getNodeName = pod => get(pod, 'spec.nodeName');
 
 export const getVmiIpAddresses = vmi => get(vmi, 'status.interfaces', []).map(i => i.ipAddress);


### PR DESCRIPTION
With this patch the DesktopViewer is added among other console types.

TODO:
- [x] have pf-react #989 merged, upgrade dependency version
- [x] maybe a follow-up: pass console details as an object instead of getter function
- [x] render only if either VM's VNC or RDP service is exposed (port, route)
