### PR TITLE
Disable VM editing if VM is running

### DIFF
--- a/sass/components/VmDetails/vm-details.scss
+++ b/sass/components/VmDetails/vm-details.scss
@@ -1,3 +1,9 @@
 .kubevirt-vm-details__description {
   margin-right: 40px;
 }
+
+.kubevirt-vm-details__edit-info {
+  display: inline-block;
+  font-size: 80%;
+  padding-right: 15px;
+}

--- a/src/components/Details/VmDetails/fixtures/VmDetails.fixture.js
+++ b/src/components/Details/VmDetails/fixtures/VmDetails.fixture.js
@@ -79,11 +79,7 @@ export const vmFixtures = {
           },
         },
       },
-      running: true,
-    },
-    status: {
-      ready: true,
-      created: true,
+      running: false,
     },
   },
   vmWithSmallFlavor: {

--- a/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
+++ b/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
@@ -213,9 +213,9 @@ exports[`<VmDetails /> renders CPU and Memory settings for VM with custom flavor
               <div>
                 <span
                   aria-hidden="true"
-                  class="kubevirt-vm-status__icon pficon pficon-on-running"
+                  class="kubevirt-vm-status__icon pficon pficon-off"
                 />
-                Running
+                Off
               </div>
             </dd>
             <dt>
@@ -310,8 +310,22 @@ exports[`<VmDetails /> renders IP addresses correctly 1`] = `
   >
     Virtual Machine Overview
     <div>
+      <div
+        class="kubevirt-vm-details__edit-info"
+      >
+        <button
+          class="popover-pf-info btn btn-link"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="pficon pficon-info"
+          />
+        </button>
+      </div>
       <button
         class="btn btn-default"
+        disabled=""
         type="button"
       >
         Edit
@@ -906,8 +920,22 @@ exports[`<VmDetails /> renders on status correctly 1`] = `
   >
     Virtual Machine Overview
     <div>
+      <div
+        class="kubevirt-vm-details__edit-info"
+      >
+        <button
+          class="popover-pf-info btn btn-link"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="pficon pficon-info"
+          />
+        </button>
+      </div>
       <button
         class="btn btn-default"
+        disabled=""
         type="button"
       >
         Edit


### PR DESCRIPTION
@andybraren This is how edit VM details currently looks like

I know that in the desing you have edit button as a part of Actions dropdown but this is currently not possible
![edit_stopped](https://user-images.githubusercontent.com/2078045/50968067-513eb180-14da-11e9-93eb-704b04fda7ea.png)

I need to disable editing if VM is running and I would like to let the user know why. Is this solution ok ?
![edit_running](https://user-images.githubusercontent.com/2078045/50968070-526fde80-14da-11e9-8b33-a6dbda6040e0.png)

Editing in progress
![edit_triggered](https://user-images.githubusercontent.com/2078045/50968074-5439a200-14da-11e9-85ec-fd69a4d5c941.png)


