### PR TITLE
VmConsoles: Connection is kept by default when switching console types

### DIFF
--- a/src/components/VmConsoles/VmConsoles.js
+++ b/src/components/VmConsoles/VmConsoles.js
@@ -115,7 +115,7 @@ export const VmConsoles = ({ vm, vmi, onStartVm, vnc, serial, rdp, WSFactory, Lo
   return (
     <div className="co-m-pane__body">
       {infoMessage}
-      <AccessConsoles preselectedType={VNC_CONSOLE_TYPE}>
+      <AccessConsoles preselectedType={VNC_CONSOLE_TYPE} disconnectByChange={false}>
         <SerialConsoleConnector type={SERIAL_CONSOLE_TYPE} WSFactory={WSFactory} {...serial} />
         <VncConsole {...vnc} />
         {(vncManual || rdpManual) && <DesktopViewer vnc={vncManual} rdp={rdpManual} />}

--- a/src/components/VmConsoles/tests/__snapshots__/VmConsoles.test.js.snap
+++ b/src/components/VmConsoles/tests/__snapshots__/VmConsoles.test.js.snap
@@ -99,7 +99,6 @@ exports[`<VmConsoles /> renders correctly for a running VM 1`] = `
             title=""
           >
             <input
-              checked=""
               type="checkbox"
             />
             Disconnect before switching


### PR DESCRIPTION
This helps to prevent failures when reconnecting.

**Partial** workaround for https://github.com/kubevirt/kubevirt/issues/1893