### PR TITLE
Clear IP addresses & FQDN when VM is off

### DIFF
--- a/src/components/Details/VmDetails/VmDetails.js
+++ b/src/components/Details/VmDetails/VmDetails.js
@@ -15,6 +15,7 @@ import {
   getUpdateDescriptionPatch,
   getUpdateFlavorPatch,
   getOperatingSystemName,
+  getHostName,
 } from '../../../utils';
 import { VirtualMachineModel } from '../../../models';
 import { CUSTOM_FLAVOR, DASHES, VM_STATUS_OFF } from '../../../constants';
@@ -133,7 +134,8 @@ export class VmDetails extends React.Component {
     } = this.props;
     const vmIsOff = this.isVmOff(vm, launcherPod, importerPods, migration);
     const nodeName = getNodeName(launcherPod);
-    const ipAddresses = getVmiIpAddresses(vmi);
+    const ipAddresses = vmIsOff ? [] : getVmiIpAddresses(vmi);
+    const fqdn = vmIsOff ? DASHES : getHostName(launcherPod);
     const template = getVmTemplate(vm);
     const editButton = (
       <Fragment>
@@ -215,7 +217,7 @@ export class VmDetails extends React.Component {
               <Col lg={4} md={4} sm={4} xs={4} id="details-column-2">
                 <dl>
                   <dt>FQDN</dt>
-                  <dd>{get(launcherPod, 'spec.hostname', DASHES)}</dd>
+                  <dd>{fqdn}</dd>
 
                   <dt>Namespace</dt>
                   <dd>{NamespaceResourceLink ? <NamespaceResourceLink /> : DASHES}</dd>

--- a/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
+++ b/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
@@ -418,9 +418,7 @@ exports[`<VmDetails /> renders IP addresses correctly 1`] = `
             <dt>
               FQDN
             </dt>
-            <dd>
-              ---
-            </dd>
+            <dd />
             <dt>
               Namespace
             </dt>
@@ -1028,9 +1026,7 @@ exports[`<VmDetails /> renders on status correctly 1`] = `
             <dt>
               FQDN
             </dt>
-            <dd>
-              ---
-            </dd>
+            <dd />
             <dt>
               Namespace
             </dt>

--- a/src/utils/selectors.js
+++ b/src/utils/selectors.js
@@ -94,6 +94,8 @@ const readValueFromObject = (objects, key, split) => {
 };
 
 export const isWindows = vm => (getOperatingSystem(vm) || '').startsWith(OS_WINDOWS_PREFIX);
+
 export const getNodeName = pod => get(pod, 'spec.nodeName');
+export const getHostName = pod => get(pod, 'spec.hostname');
 
 export const getVmiIpAddresses = vmi => get(vmi, 'status.interfaces', []).map(i => i.ipAddress);


### PR DESCRIPTION
This PR fixes a bug [1] wherein the VMI isn't immediately deleted when the VM is shutdown, leading to the IP addresses still being displayed when the VM is in an off state. It also prevents the FQDN from being displayed if the pod isn't immediately deleted to avoid the potential of a similar issue occurring. 

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1665901.