### PR TITLE
Fix VM details issues

### DIFF
--- a/src/components/Details/VmDetails/VmDetails.js
+++ b/src/components/Details/VmDetails/VmDetails.js
@@ -135,7 +135,8 @@ export class VmDetails extends React.Component {
     const vmIsOff = this.isVmOff(vm, launcherPod, importerPods, migration);
     const nodeName = getNodeName(launcherPod);
     const ipAddresses = vmIsOff ? [] : getVmiIpAddresses(vmi);
-    const fqdn = vmIsOff ? DASHES : getHostName(launcherPod);
+    const hostName = getHostName(launcherPod);
+    const fqdn = vmIsOff || !hostName ? DASHES : hostName;
     const template = getVmTemplate(vm);
     const editButton = (
       <Fragment>

--- a/src/components/Details/VmDetails/fixtures/VmDetails.fixture.js
+++ b/src/components/Details/VmDetails/fixtures/VmDetails.fixture.js
@@ -93,10 +93,28 @@ export const vmFixtures = {
   },
 };
 
+const vmiFixture = {
+  apiVersion: 'kubevirt.io/v1alpha3',
+  kind: 'VirtualMachineInstance',
+  metadata: {
+    name: 'my-vm-vmi',
+    namespace: 'my-namespace',
+  },
+  status: {
+    interfaces: [
+      { ipAddress: '172.17.0.15', mac: '02:42:ac:11:00:0d', name: 'default' },
+      { ipAddress: '172.17.0.16', mac: '02:42:ac:11:00:0e', name: 'backup1' },
+      { ipAddress: '172.17.0.17', mac: '02:42:ac:11:00:0f', name: 'backup2' },
+    ],
+    nodeName: 'localhost',
+    phase: 'Running',
+  },
+};
+
 export default [
   {
     component: VmDetails,
-    name: 'offline VM',
+    name: 'Offline VM',
     props: {
       vm: vmFixtures.downVm,
       k8sPatch: () =>
@@ -111,9 +129,10 @@ export default [
   },
   {
     component: VmDetails,
-    name: 'running VM',
+    name: 'Running VM',
     props: {
       vm: vmFixtures.runningVm,
+      vmi: vmiFixture,
       k8sPatch: () =>
         new Promise(resolve => {
           resolve();

--- a/src/components/Details/VmDetails/tests/VmDetails.test.js
+++ b/src/components/Details/VmDetails/tests/VmDetails.test.js
@@ -120,6 +120,7 @@ describe('<VmDetails /> enzyme', () => {
       ).toBeTruthy();
     });
   });
+
   it('disables edit mode when clicked on cancel', () => {
     const component = mount(testVmDetails(vmFixtures.vmWithLabels));
     return awaitVmDetails(() => {
@@ -133,6 +134,7 @@ describe('<VmDetails /> enzyme', () => {
       return component;
     });
   });
+
   it('updates VM description after clicking save button', () => {
     const k8sPatchMock = jest.fn().mockReturnValue(
       new Promise(resolve => {

--- a/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
+++ b/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
@@ -418,7 +418,9 @@ exports[`<VmDetails /> renders IP addresses correctly 1`] = `
             <dt>
               FQDN
             </dt>
-            <dd />
+            <dd>
+              ---
+            </dd>
             <dt>
               Namespace
             </dt>
@@ -1026,7 +1028,9 @@ exports[`<VmDetails /> renders on status correctly 1`] = `
             <dt>
               FQDN
             </dt>
-            <dd />
+            <dd>
+              ---
+            </dd>
             <dt>
               Namespace
             </dt>

--- a/src/utils/selectors.js
+++ b/src/utils/selectors.js
@@ -98,4 +98,7 @@ export const isWindows = vm => (getOperatingSystem(vm) || '').startsWith(OS_WIND
 export const getNodeName = pod => get(pod, 'spec.nodeName');
 export const getHostName = pod => get(pod, 'spec.hostname');
 
-export const getVmiIpAddresses = vmi => get(vmi, 'status.interfaces', []).map(i => i.ipAddress);
+export const getVmiIpAddresses = vmi =>
+  get(vmi, 'status.interfaces', [])
+    .map(i => i.ipAddress)
+    .filter(ip => ip && ip.trim().length > 0);

--- a/src/utils/tests/selectors.test.js
+++ b/src/utils/tests/selectors.test.js
@@ -18,4 +18,14 @@ describe('getVmiIpAddresses()', () => {
     delete cloudInitTestVmi.status.interfaces;
     expect(getVmiIpAddresses(cloudInitTestVmi)).toHaveLength(0);
   });
+
+  it('removes empty and missing IP addresses', () => {
+    cloudInitTestVmi.status.interfaces = [
+      { ipAddress: '172.17.0.15', mac: '02:42:ac:11:00:0d', name: 'default' },
+      { ipAddress: '', mac: '02:42:ac:11:00:0c', name: 'nic-1' },
+      { ipAddress: ' ', mac: '02:42:ac:11:00:0e', name: 'nic-2' },
+      { mac: '02:42:ac:11:00:0f', name: 'nic-3' },
+    ];
+    expect(getVmiIpAddresses(cloudInitTestVmi)).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
This PR addresses the following issues in the VM details dialog:

- Removes trailing comma when interfaces with missing/empty IP addresses are present
-- https://bugzilla.redhat.com/1668351
- Always displays dashes for the FQDN when the FQDN isn't available