### PR TITLE
Add view-only boot order component to VM details dialog

### DIFF
--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -11,6 +11,7 @@
 @import './components/Table/editable-table';
 @import './components/TemplateSource/template-source';
 @import './components/VmConsoles/desktop-viewer-selector';
+@import './components/VmDetails/boot-order';
 @import './components/VmDetails/vm-details';
 @import './components/VmStatus/vm-status';
 @import './components/Wizard/create-vm-wizard';

--- a/sass/components/VmDetails/boot-order.scss
+++ b/sass/components/VmDetails/boot-order.scss
@@ -1,0 +1,4 @@
+.kubevirt-boot-order__list {
+  padding-left: 0;
+  list-style-position: inside;
+}

--- a/src/components/Details/BootOrder/BootOrder.js
+++ b/src/components/Details/BootOrder/BootOrder.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const BootOrder = props => {
+  const { bootableDevices } = props;
+  const sortedBootableDevices = bootableDevices.sort((a, b) => a.bootOrder - b.bootOrder);
+  const listItems = sortedBootableDevices.map((dev, idx) => <li key={`${idx}-${dev.name}`}>{dev.name}</li>);
+
+  return <ol className="kubevirt-boot-order__list">{listItems}</ol>;
+};
+
+BootOrder.propTypes = {
+  bootableDevices: PropTypes.array.isRequired,
+};

--- a/src/components/Details/BootOrder/BootOrder.js
+++ b/src/components/Details/BootOrder/BootOrder.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const BootOrder = props => {
-  const { bootableDevices } = props;
-  const sortedBootableDevices = bootableDevices.sort((a, b) => a.bootOrder - b.bootOrder);
-  const listItems = sortedBootableDevices.map((dev, idx) => <li key={`${idx}-${dev.name}`}>{dev.name}</li>);
+export const BootOrder = ({ bootableDevices }) => {
+  const listItems = bootableDevices.map((dev, idx) => <li key={`${idx}-${dev.value.name}`}>{dev.value.name}</li>);
 
   return <ol className="kubevirt-boot-order__list">{listItems}</ol>;
 };

--- a/src/components/Details/BootOrder/fixtures/BootOrder.fixture.js
+++ b/src/components/Details/BootOrder/fixtures/BootOrder.fixture.js
@@ -1,11 +1,11 @@
 import { BootOrder } from '../BootOrder';
 
 export const bootableDevices = [
-  { bridge: {}, name: 'podNetworkName', bootOrder: 2 },
-  { disk: {}, name: 'disk-two', bootOrder: 4 },
-  { disk: {}, name: 'disk-three', bootOrder: 5 },
-  { disk: {}, name: 'disk-one', bootOrder: 3 },
-  { bridge: {}, name: 'pxeNetworkName', bootOrder: 1 },
+  { type: 'interface', value: { bridge: {}, name: 'pxeNetworkName', bootOrder: 1 } },
+  { type: 'interface', value: { bridge: {}, name: 'podNetworkName', bootOrder: 2 } },
+  { type: 'disk', value: { disk: {}, name: 'disk-one', bootOrder: 3 } },
+  { type: 'disk', value: { disk: {}, name: 'disk-two', bootOrder: 4 } },
+  { type: 'disk', value: { disk: {}, name: 'disk-three', bootOrder: 5 } },
 ];
 
 export default [

--- a/src/components/Details/BootOrder/fixtures/BootOrder.fixture.js
+++ b/src/components/Details/BootOrder/fixtures/BootOrder.fixture.js
@@ -1,0 +1,19 @@
+import { BootOrder } from '../BootOrder';
+
+export const bootableDevices = [
+  { bridge: {}, name: 'podNetworkName', bootOrder: 2 },
+  { disk: {}, name: 'disk-two', bootOrder: 4 },
+  { disk: {}, name: 'disk-three', bootOrder: 5 },
+  { disk: {}, name: 'disk-one', bootOrder: 3 },
+  { bridge: {}, name: 'pxeNetworkName', bootOrder: 1 },
+];
+
+export default [
+  {
+    component: BootOrder,
+    name: 'BootOrder',
+    props: {
+      bootableDevices,
+    },
+  },
+];

--- a/src/components/Details/BootOrder/index.js
+++ b/src/components/Details/BootOrder/index.js
@@ -1,0 +1,1 @@
+export { BootOrder } from './BootOrder';

--- a/src/components/Details/BootOrder/tests/BootOrder.test.js
+++ b/src/components/Details/BootOrder/tests/BootOrder.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render } from 'enzyme/build';
+
+import { default as BootOrderFixture } from '../fixtures/BootOrder.fixture';
+import { BootOrder } from '../BootOrder';
+
+describe('<BootOrder />', () => {
+  it('renders correctly', () => {
+    const component = render(<BootOrder {...BootOrderFixture[0].props} />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/Details/BootOrder/tests/__snapshots__/BootOrder.test.js.snap
+++ b/src/components/Details/BootOrder/tests/__snapshots__/BootOrder.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<BootOrder /> renders correctly 1`] = `
+<ol
+  class="kubevirt-boot-order__list"
+>
+  <li>
+    pxeNetworkName
+  </li>
+  <li>
+    podNetworkName
+  </li>
+  <li>
+    disk-one
+  </li>
+  <li>
+    disk-two
+  </li>
+  <li>
+    disk-three
+  </li>
+</ol>
+`;

--- a/src/components/Details/VmDetails/VmDetails.js
+++ b/src/components/Details/VmDetails/VmDetails.js
@@ -30,7 +30,7 @@ import { Description } from '../Description';
 import { Loading } from '../../Loading';
 import { DESCRIPTION_KEY, FLAVOR_KEY } from '../common/constants';
 import { BootOrder } from '../BootOrder';
-import { getBootableDevices } from '../../../k8s/vmBuilder';
+import { getBootableDevicesInOrder } from '../../../k8s/vmBuilder';
 
 export class VmDetails extends React.Component {
   constructor(props) {
@@ -149,7 +149,7 @@ export class VmDetails extends React.Component {
     const fqdn = vmIsOff || !hostName ? DASHES : hostName;
     const template = getVmTemplate(vm);
     const id = getId(vm);
-    const bootableDevices = getBootableDevices(vm);
+    const sortedBootableDevices = getBootableDevicesInOrder(vm);
     const editButton = (
       <Fragment>
         {!vmIsOff && (
@@ -245,7 +245,9 @@ export class VmDetails extends React.Component {
                   <dd>{PodResourceLink ? <PodResourceLink /> : DASHES}</dd>
 
                   <dt>Boot Order</dt>
-                  <dd>{bootableDevices.length > 0 ? <BootOrder bootableDevices={bootableDevices} /> : DASHES}</dd>
+                  <dd>
+                    {sortedBootableDevices.length > 0 ? <BootOrder bootableDevices={sortedBootableDevices} /> : DASHES}
+                  </dd>
                 </dl>
               </Col>
 

--- a/src/components/Details/VmDetails/VmDetails.js
+++ b/src/components/Details/VmDetails/VmDetails.js
@@ -29,6 +29,8 @@ import { Flavor } from '../Flavor';
 import { Description } from '../Description';
 import { Loading } from '../../Loading';
 import { DESCRIPTION_KEY, FLAVOR_KEY } from '../common/constants';
+import { BootOrder } from '../BootOrder';
+import { getBootableDevices } from '../../../k8s/vmBuilder';
 
 export class VmDetails extends React.Component {
   constructor(props) {
@@ -147,7 +149,7 @@ export class VmDetails extends React.Component {
     const fqdn = vmIsOff || !hostName ? DASHES : hostName;
     const template = getVmTemplate(vm);
     const id = getId(vm);
-
+    const bootableDevices = getBootableDevices(vm);
     const editButton = (
       <Fragment>
         {!vmIsOff && (
@@ -240,6 +242,10 @@ export class VmDetails extends React.Component {
 
                   <dt>Pod</dt>
                   <dd id={prefixedId(id, 'pod')}>{PodResourceLink ? <PodResourceLink /> : DASHES}</dd>
+                  <dd>{PodResourceLink ? <PodResourceLink /> : DASHES}</dd>
+
+                  <dt>Boot Order</dt>
+                  <dd>{bootableDevices.length > 0 ? <BootOrder bootableDevices={bootableDevices} /> : DASHES}</dd>
                 </dl>
               </Col>
 

--- a/src/components/Details/VmDetails/fixtures/VmDetails.fixture.js
+++ b/src/components/Details/VmDetails/fixtures/VmDetails.fixture.js
@@ -23,7 +23,27 @@ export const vmFixtures = {
   },
   runningVm: {
     metadata,
-    spec: { running: true },
+    spec: {
+      template: {
+        spec: {
+          domain: {
+            devices: {
+              rng: {},
+              interfaces: [
+                { bridge: {}, name: 'podNetworkName', bootOrder: 2 },
+                { bridge: {}, name: 'pxeNetworkName', bootOrder: 1 },
+              ],
+              disks: [
+                { disk: {}, name: 'disk-one', bootOrder: 3 },
+                { disk: {}, name: 'disk-two', bootOrder: 4 },
+                { disk: {}, name: 'disk-three', bootOrder: 5 },
+              ],
+            },
+          },
+        },
+      },
+      running: true,
+    },
     status: {
       ready: true,
       created: true,

--- a/src/components/Details/VmDetails/fixtures/VmDetails.fixture.js
+++ b/src/components/Details/VmDetails/fixtures/VmDetails.fixture.js
@@ -37,9 +37,18 @@ export const vmFixtures = {
                 { disk: {}, name: 'disk-one', bootOrder: 3 },
                 { disk: {}, name: 'disk-two', bootOrder: 4 },
                 { disk: {}, name: 'disk-three', bootOrder: 5 },
+                { disk: { bus: 'virtio' }, name: 'cloudinitdisk' },
               ],
             },
           },
+          volumes: [
+            {
+              cloudInitNoCloud: {
+                userData: '# configure default password\npassword: fedora\nchpasswd: { expire: False }',
+              },
+              name: 'cloudinitdisk',
+            },
+          ],
         },
       },
       running: true,

--- a/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
+++ b/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
@@ -136,6 +136,15 @@ exports[`<VmDetails /> does not render CPU and Memory settings for VM without cu
             >
               ---
             </dd>
+            <dd>
+              ---
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
+              ---
+            </dd>
           </dl>
         </div>
         <div
@@ -308,6 +317,15 @@ exports[`<VmDetails /> renders CPU and Memory settings for VM with custom flavor
             <dd
               id="my-namespace-my-vm-pod"
             >
+              ---
+            </dd>
+            <dd>
+              ---
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
               ---
             </dd>
           </dl>
@@ -500,6 +518,33 @@ exports[`<VmDetails /> renders IP addresses correctly 1`] = `
             >
               ---
             </dd>
+            <dd>
+              ---
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
+              <ol
+                class="kubevirt-boot-order__list"
+              >
+                <li>
+                  pxeNetworkName
+                </li>
+                <li>
+                  podNetworkName
+                </li>
+                <li>
+                  disk-one
+                </li>
+                <li>
+                  disk-two
+                </li>
+                <li>
+                  disk-three
+                </li>
+              </ol>
+            </dd>
           </dl>
         </div>
         <div
@@ -672,6 +717,15 @@ exports[`<VmDetails /> renders correctly 1`] = `
             <dd
               id="my-namespace-my-vm-pod"
             >
+              ---
+            </dd>
+            <dd>
+              ---
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
               ---
             </dd>
           </dl>
@@ -848,6 +902,15 @@ exports[`<VmDetails /> renders description correctly 1`] = `
             >
               ---
             </dd>
+            <dd>
+              ---
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
+              ---
+            </dd>
           </dl>
         </div>
         <div
@@ -1020,6 +1083,15 @@ exports[`<VmDetails /> renders off status correctly 1`] = `
             <dd
               id="my-namespace-my-vm-pod"
             >
+              ---
+            </dd>
+            <dd>
+              ---
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
               ---
             </dd>
           </dl>
@@ -1210,6 +1282,33 @@ exports[`<VmDetails /> renders on status correctly 1`] = `
             >
               ---
             </dd>
+            <dd>
+              ---
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
+              <ol
+                class="kubevirt-boot-order__list"
+              >
+                <li>
+                  pxeNetworkName
+                </li>
+                <li>
+                  podNetworkName
+                </li>
+                <li>
+                  disk-one
+                </li>
+                <li>
+                  disk-two
+                </li>
+                <li>
+                  disk-three
+                </li>
+              </ol>
+            </dd>
           </dl>
         </div>
         <div
@@ -1382,6 +1481,15 @@ exports[`<VmDetails /> renders values from labels correctly 1`] = `
             <dd
               id="my-namespace-my-vm-pod"
             >
+              ---
+            </dd>
+            <dd>
+              ---
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
               ---
             </dd>
           </dl>

--- a/src/components/Details/VmTemplateDetails/VmTemplateDetails.js
+++ b/src/components/Details/VmTemplateDetails/VmTemplateDetails.js
@@ -27,6 +27,8 @@ import { Description } from '../Description';
 import { Loading } from '../../Loading';
 import { TemplateSource } from '../../TemplateSource';
 import { DESCRIPTION_KEY, FLAVOR_KEY } from '../common/constants';
+import { getBootableDevicesInOrder } from '../../../k8s/vmBuilder';
+import { BootOrder } from '../BootOrder';
 
 export class VmTemplateDetails extends React.Component {
   constructor(props) {
@@ -124,6 +126,7 @@ export class VmTemplateDetails extends React.Component {
     const id = getId(vmTemplate);
     const vm = selectVm(vmTemplate.objects);
     const baseTemplate = getVmTemplate(vmTemplate);
+    const sortedBootableDevices = getBootableDevicesInOrder(vm);
 
     const editButton = (
       <Button disabled={this.state.updating} onClick={() => this.setEditing(true)}>
@@ -193,6 +196,11 @@ export class VmTemplateDetails extends React.Component {
                   </dd>
                   <dt>Namespace</dt>
                   <dd id={prefixedId(id, 'namespace')}>{NamespaceResourceLink ? <NamespaceResourceLink /> : DASHES}</dd>
+                  <dd>{NamespaceResourceLink ? <NamespaceResourceLink /> : DASHES}</dd>
+                  <dt>Boot Order</dt>
+                  <dd>
+                    {sortedBootableDevices.length > 0 ? <BootOrder bootableDevices={sortedBootableDevices} /> : DASHES}
+                  </dd>
                 </dl>
               </Col>
 

--- a/src/components/Details/VmTemplateDetails/tests/__snapshots__/VmTemplateDetails.test.js.snap
+++ b/src/components/Details/VmTemplateDetails/tests/__snapshots__/VmTemplateDetails.test.js.snap
@@ -118,6 +118,21 @@ exports[`<VmTemplateDetails /> renders container correctly 1`] = `
             >
               myproject
             </dd>
+            <dd>
+              myproject
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
+              <ol
+                class="kubevirt-boot-order__list"
+              >
+                <li>
+                  rootdisk
+                </li>
+              </ol>
+            </dd>
           </dl>
         </div>
         <div
@@ -260,6 +275,24 @@ exports[`<VmTemplateDetails /> renders pxe correctly 1`] = `
               id="myproject-pxe-template-dv-namespace"
             >
               myproject
+            </dd>
+            <dd>
+              myproject
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
+              <ol
+                class="kubevirt-boot-order__list"
+              >
+                <li>
+                  eth1
+                </li>
+                <li>
+                  fooDvDisk
+                </li>
+              </ol>
             </dd>
           </dl>
         </div>
@@ -415,6 +448,21 @@ exports[`<VmTemplateDetails /> renders url correctly 1`] = `
               id="myproject-url-template-namespace"
             >
               myproject
+            </dd>
+            <dd>
+              myproject
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
+              <ol
+                class="kubevirt-boot-order__list"
+              >
+                <li>
+                  rootdisk
+                </li>
+              </ol>
             </dd>
           </dl>
         </div>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -17,6 +17,9 @@ export const KUBEVIRT_API_VERSION = 'kubevirt.io/v1alpha3';
 export const OS_LABEL = 'kubevirt.io/os';
 export const POD_NETWORK = 'Pod Networking';
 
+export const DEVICE_TYPE_INTERFACE = 'interfaces';
+export const DEVICE_TYPE_DISK = 'disks';
+
 export const PROVISION_SOURCE_PXE = 'PXE';
 export const PROVISION_SOURCE_CONTAINER = 'Container';
 export const PROVISION_SOURCE_URL = 'URL';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -17,8 +17,15 @@ export const KUBEVIRT_API_VERSION = 'kubevirt.io/v1alpha3';
 export const OS_LABEL = 'kubevirt.io/os';
 export const POD_NETWORK = 'Pod Networking';
 
-export const DEVICE_TYPE_INTERFACE = 'interfaces';
-export const DEVICE_TYPE_DISK = 'disks';
+export const DEVICE_TYPE_INTERFACE = 'interface';
+export const DEVICE_TYPE_DISK = 'disk';
+export const INTERFACE_PATH_KEY = 'interfaces';
+export const DISK_PATH_KEY = 'disks';
+
+export const deviceTypeToPathKey = {
+  [DEVICE_TYPE_INTERFACE]: INTERFACE_PATH_KEY,
+  [DEVICE_TYPE_DISK]: DISK_PATH_KEY,
+};
 
 export const PROVISION_SOURCE_PXE = 'PXE';
 export const PROVISION_SOURCE_CONTAINER = 'Container';

--- a/src/k8s/request.js
+++ b/src/k8s/request.js
@@ -99,6 +99,7 @@ import {
   addVolume,
   removeDisksAndVolumes,
   getDataVolumeTemplateSpec,
+  sequentializeBootOrderIndexes,
 } from './vmBuilder';
 
 import { getImportProviderSecretObject } from '../components/Wizard/CreateVmWizard/providers/vmwareProviderPod';
@@ -201,7 +202,7 @@ export const createVm = async (k8sCreate, templates, basicSettings, networks, st
     persistentVolumeClaims
   );
 
-  // ProcessedTemplates endpoit will reject the request if user cannot post to the namespace
+  // ProcessedTemplates endpoint will reject the request if user cannot post to the namespace
   // common-templates are stored in openshift namespace, default user can read but cannot post
   const postTemplate = cloneDeep(template);
   postTemplate.metadata.namespace = settingsValue(basicSettings, NAMESPACE_KEY);
@@ -209,6 +210,8 @@ export const createVm = async (k8sCreate, templates, basicSettings, networks, st
   const processedTemplate = await create(ProcessedTemplatesModel, postTemplate);
 
   const vm = selectVm(processedTemplate.objects);
+
+  sequentializeBootOrderIndexes(vm);
 
   addMetadata(vm, template, getSetting);
 

--- a/src/k8s/request.js
+++ b/src/k8s/request.js
@@ -170,6 +170,8 @@ export const createVmTemplate = async (
     bootDataVolume.kind = DataVolumeModel.kind;
   }
 
+  sequentializeBootOrderIndexes(selectVm(template.objects));
+
   const templateResult = await create(TemplateModel, vmTemplate);
 
   const results = [templateResult];

--- a/src/k8s/tests/request.test.js
+++ b/src/k8s/tests/request.test.js
@@ -227,7 +227,7 @@ describe('request.js - networks', () => {
       expect(vm.spec.template.spec.domain.devices.autoattachPodInterface).toBeUndefined();
       expect(vm.spec.template.spec.domain.devices.interfaces).toHaveLength(1);
       expect(vm.spec.template.spec.domain.devices.interfaces[0].name).toEqual(podNetwork.name);
-      expect(vm.spec.template.spec.domain.devices.interfaces[0].bootOrder).toBeGreaterThan(0);
+      expect(vm.spec.template.spec.domain.devices.interfaces[0].bootOrder).toEqual(1);
       expect(vm.spec.template.spec.networks).toHaveLength(1);
       expect(vm.spec.template.spec.networks[0].name).toEqual(podNetwork.name);
       expect(vm.spec.template.spec.networks[0].pod).toEqual({});

--- a/src/k8s/tests/request.test.js
+++ b/src/k8s/tests/request.test.js
@@ -227,7 +227,7 @@ describe('request.js - networks', () => {
       expect(vm.spec.template.spec.domain.devices.autoattachPodInterface).toBeUndefined();
       expect(vm.spec.template.spec.domain.devices.interfaces).toHaveLength(1);
       expect(vm.spec.template.spec.domain.devices.interfaces[0].name).toEqual(podNetwork.name);
-      expect(vm.spec.template.spec.domain.devices.interfaces[0].bootOrder).toBeUndefined();
+      expect(vm.spec.template.spec.domain.devices.interfaces[0].bootOrder).toBeGreaterThan(0);
       expect(vm.spec.template.spec.networks).toHaveLength(1);
       expect(vm.spec.template.spec.networks[0].name).toEqual(podNetwork.name);
       expect(vm.spec.template.spec.networks[0].pod).toEqual({});

--- a/src/k8s/tests/request.test.js
+++ b/src/k8s/tests/request.test.js
@@ -88,9 +88,9 @@ const testDataVolumeStorage = (
 
 const testStorage = (vm, storageIndex, bootOrder, expectedName) => {
   expect(vm.spec.template.spec.domain.devices.disks[storageIndex].name).toBe(expectedName);
-  expect(vm.spec.template.spec.domain.devices.disks[storageIndex].bootOrder).toBe(
-    bootOrder !== -1 ? bootOrder : undefined
-  );
+  vm.spec.template.spec.domain.devices.disks.forEach(disk => {
+    expect(disk.bootOrder).toBeGreaterThanOrEqual(1);
+  });
   expect(vm.spec.template.spec.volumes[storageIndex].name).toBe(expectedName);
 };
 

--- a/src/k8s/tests/request.test.js
+++ b/src/k8s/tests/request.test.js
@@ -88,9 +88,7 @@ const testDataVolumeStorage = (
 
 const testStorage = (vm, storageIndex, bootOrder, expectedName) => {
   expect(vm.spec.template.spec.domain.devices.disks[storageIndex].name).toBe(expectedName);
-  vm.spec.template.spec.domain.devices.disks.forEach(disk => {
-    expect(disk.bootOrder).toBeGreaterThanOrEqual(1);
-  });
+  expect(vm.spec.template.spec.domain.devices.disks[storageIndex].bootOrder).toEqual(bootOrder);
   expect(vm.spec.template.spec.volumes[storageIndex].name).toBe(expectedName);
 };
 
@@ -205,7 +203,7 @@ describe('request.js - provision sources', () => {
 
       expect(vm.spec.template.spec.volumes).toHaveLength(2);
       expect(vm.spec.template.spec.domain.devices.disks).toHaveLength(2);
-      testPvcStorage(results, 0, 0, -1, pvcDisk.name, getNamespace(results[0]));
+      testPvcStorage(results, 0, 0, 2, pvcDisk.name, getNamespace(results[0]));
       testDataVolumeStorage(
         results,
         1,
@@ -262,7 +260,7 @@ describe('request.js - networks', () => {
     createVm(k8sCreate, templates, basicSettingsCustomFlavor, [], [], persistentVolumeClaims).then(results => {
       const vm = results[0];
       expect(vm.spec.template.spec.domain.devices.autoattachPodInterface).toBeFalsy();
-      expect(vm.spec.template.spec.domain.devices.interfaces).toBeUndefined();
+      expect(vm.spec.template.spec.domain.devices.interfaces).toHaveLength(0);
       expect(vm.spec.template.spec.networks).toBeUndefined();
       return results;
     }));
@@ -296,7 +294,7 @@ describe('request.js - networks', () => {
       persistentVolumeClaims
     ).then(results => {
       testPXE(results, false);
-      testPvcStorage(results, 0, 0, 2, pvcDisk.name, getNamespace(results[0]));
+      testPvcStorage(results, 0, 0, 3, pvcDisk.name, getNamespace(results[0]));
       return results;
     });
   });
@@ -408,14 +406,14 @@ describe('request.js - storages', () => {
       persistentVolumeClaims
     ).then(results => {
       testContainerImage(results);
-      testPvcStorage(results, 1, 0, -1, pvcDisk.name, getNamespace(results[0]));
+      testPvcStorage(results, 1, 0, 2, pvcDisk.name, getNamespace(results[0]));
       return results;
     }));
 
   it('url source with attached disks', () =>
     createVm(k8sCreate, templates, basicSettingsUrl, [], [rootDataVolumeDisk, pvcDisk], persistentVolumeClaims).then(
       results => {
-        testPvcStorage(results, 1, 1, -1, pvcDisk.name, getNamespace(results[0]));
+        testPvcStorage(results, 1, 1, 2, pvcDisk.name, getNamespace(results[0]));
         return results;
       }
     ));
@@ -437,7 +435,7 @@ describe('request.js - storages', () => {
         templateDataVolumeDisk.templateStorage.dataVolume.metadata.name,
         templateDataVolumeDisk.templateStorage.dataVolume.metadata.namespace
       );
-      testPvcStorage(results, 0, 0, -1, pvcDisk.name, getNamespace(results[0]));
+      testPvcStorage(results, 0, 0, 2, pvcDisk.name, getNamespace(results[0]));
       return results;
     }));
 
@@ -455,7 +453,7 @@ describe('request.js - storages', () => {
       persistentVolumeClaims
     ).then(results => {
       testPXE(results);
-      testPvcStorage(results, 0, 0, 2, pvcDisk.name, getNamespace(results[0]));
+      testPvcStorage(results, 0, 0, 3, pvcDisk.name, getNamespace(results[0]));
       return results;
     });
   });
@@ -469,7 +467,7 @@ describe('request.js - storages', () => {
       persistentVolumeClaims
     );
     expect(results).toHaveLength(1);
-    testPvcStorage(results, 0, 0, -1, pvcDisk.name, getNamespace(results[0]));
+    testPvcStorage(results, 0, 0, 3, pvcDisk.name, getNamespace(results[0]));
     return results;
   });
 });
@@ -593,6 +591,6 @@ describe('request.js - Create Vm Template', () => {
       persistentVolumeClaims
     );
     const vmTemplate = results[0];
-    testPvcStorage(vmTemplate.objects, 1, 0, -1, pvcDisk.name, getNamespace(results[0]));
+    testPvcStorage(vmTemplate.objects, 1, 0, 2, pvcDisk.name, getNamespace(results[0]));
   });
 });

--- a/src/k8s/vmBuilder.js
+++ b/src/k8s/vmBuilder.js
@@ -17,6 +17,7 @@ import {
   DATA_VOLUME_SOURCE_URL,
   DATA_VOLUME_SOURCE_BLANK,
 } from '../components/Wizard/CreateVmWizard/constants';
+import { getCloudInitVolume } from '../utils';
 
 export const addDisk = (vm, defaultDisk, storage, getSetting) => {
   const diskSpec = {
@@ -26,11 +27,18 @@ export const addDisk = (vm, defaultDisk, storage, getSetting) => {
   if (storage.isBootable) {
     const imageSource = getSetting(PROVISION_SOURCE_TYPE_KEY);
     diskSpec.bootOrder = imageSource === PROVISION_SOURCE_PXE ? assignBootOrderIndex(vm) : BOOT_ORDER_FIRST;
+  } else if (isCloudInitDisk(vm, diskSpec)) {
+    delete diskSpec.bootOrder;
   } else {
     diskSpec.bootOrder = diskSpec.bootOrder ? diskSpec.bootOrder : assignBootOrderIndex(vm);
   }
   const disks = getDisks(vm);
   disks.push(diskSpec);
+};
+
+const isCloudInitDisk = (vm, disk) => {
+  const cloudInitVolume = getCloudInitVolume(vm);
+  return cloudInitVolume && cloudInitVolume.name === disk.name;
 };
 
 export const addContainerVolume = (vm, storage, getSetting) => {

--- a/src/k8s/vmBuilder.js
+++ b/src/k8s/vmBuilder.js
@@ -309,3 +309,25 @@ const getNextAvailableBootOrderIndex = vm => {
   // assigned indexes start at two as the first index is assigned directly by the user
   return largestIdx !== -1 ? largestIdx + 1 : BOOT_ORDER_SECOND;
 };
+
+export const getBootableDevices = vm => {
+  const bootableDevices = [];
+
+  const disks = getDisks(vm);
+  disks.forEach(disk => {
+    const bootOrder = get(disk, 'bootOrder', null);
+    if (bootOrder) {
+      bootableDevices.push(disk);
+    }
+  });
+
+  const nics = getInterfaces(vm);
+  nics.forEach(nic => {
+    const bootOrder = get(nic, 'bootOrder', null);
+    if (bootOrder) {
+      bootableDevices.push(nic);
+    }
+  });
+
+  return bootableDevices;
+};

--- a/src/utils/patches.js
+++ b/src/utils/patches.js
@@ -10,6 +10,7 @@ import {
   TEMPLATE_FLAVOR_LABEL,
 } from '../constants';
 import { NETWORK_TYPE_POD } from '../components/Wizard/CreateVmWizard/constants';
+import { assignBootOrderIndex } from '../k8s/vmBuilder';
 
 export const getPxeBootPatch = vm => {
   const patches = [];
@@ -47,6 +48,7 @@ export const getPxeBootPatch = vm => {
 export const getAddDiskPatch = (vm, storage) => {
   const disk = {
     name: storage.name,
+    bootOrder: assignBootOrderIndex(vm),
   };
   if (storage.bus) {
     disk.disk = {
@@ -312,6 +314,7 @@ export const getAddNicPatch = (vm, nic) => {
     name: nic.name,
     model: nic.model,
     bridge: {},
+    bootOrder: assignBootOrderIndex(vm),
   };
   if (nic.mac) {
     i.macAddress = nic.mac;
@@ -330,7 +333,7 @@ export const getAddNicPatch = (vm, nic) => {
 
   const patch = [];
 
-  const hasInterfaces = get(vm, 'spec.template.spec.domain.devices.interfaces', false);
+  const hasInterfaces = get(vm, 'spec.template.spec.domain.devices.interfaces', []).length > 0;
   if (hasInterfaces) {
     patch.push({
       op: 'add',

--- a/src/utils/patches.js
+++ b/src/utils/patches.js
@@ -6,13 +6,13 @@ import {
   ANNOTATION_FIRST_BOOT,
   BOOT_ORDER_FIRST,
   BOOT_ORDER_SECOND,
-  DEVICE_TYPE_DISK,
-  DEVICE_TYPE_INTERFACE,
   PVC_ACCESSMODE_RWO,
   TEMPLATE_FLAVOR_LABEL,
+  deviceTypeToPathKey,
+  DEVICE_TYPE_INTERFACE,
 } from '../constants';
 import { NETWORK_TYPE_POD } from '../components/Wizard/CreateVmWizard/constants';
-import { assignBootOrderIndex, getBootableDevicesInOrder, isDisk, isNic } from '../k8s/vmBuilder';
+import { assignBootOrderIndex, getBootableDevicesInOrder, getDevices } from '../k8s/vmBuilder';
 
 export const getPxeBootPatch = vm => {
   const patches = [];
@@ -393,39 +393,35 @@ export const addPrefixToPatch = (prefix, patch) => ({
   path: `${prefix}${patch.path}`,
 });
 
-const getDeviceType = device => {
-  let type;
-  if (isNic(device)) {
-    type = DEVICE_TYPE_INTERFACE;
-  } else if (isDisk(device)) {
-    type = DEVICE_TYPE_DISK;
-  }
-
-  return type;
-};
-
-const getDeviceIndex = (device, vm) => {
-  const deviceType = getDeviceType(device);
+const getDeviceIndex = (vm, deviceName, deviceType) => {
   const devices = deviceType === DEVICE_TYPE_INTERFACE ? getInterfaces(vm) : getDisks(vm);
-
-  return findIndex(devices, d => d.name === device.name);
+  return findIndex(devices, d => d.name === deviceName);
 };
 
-export const getDeviceBootOrderPatch = (vm, removedBootOrderIdx) => {
+export const getDeviceBootOrderPatch = (vm, removedDevicePathKey, removedDeviceName) => {
   const patches = [];
+  const removedDevice = get(getDevices(vm), removedDevicePathKey, []).find(dev => dev.name === removedDeviceName);
+  const removedDeviceBootOrder = get(removedDevice, 'bootOrder', -1);
+  const removedDeviceIndex = getDeviceIndex(vm, removedDeviceName, removedDevicePathKey);
   const sortedBootableDevices = getBootableDevicesInOrder(vm);
 
   sortedBootableDevices.forEach(device => {
-    const bootOrder = get(device, 'bootOrder', -1);
+    const bootOrder = get(device, 'value.bootOrder', -1);
 
-    if (bootOrder !== -1 && bootOrder > removedBootOrderIdx) {
-      const deviceIndex = getDeviceIndex(device, vm);
-      const deviceType = getDeviceType(device);
+    if (bootOrder !== -1 && bootOrder > removedDeviceBootOrder) {
+      const deviceType = get(device, 'type');
+      const deviceTypePathKey = deviceTypeToPathKey[deviceType];
+      const currDevIndex = getDeviceIndex(vm, device.value.name, deviceType);
+      // Account for index change once device is removed
+      const deviceIndex =
+        deviceTypePathKey === removedDevicePathKey && currDevIndex > removedDeviceIndex
+          ? currDevIndex - 1
+          : currDevIndex;
 
       if (deviceIndex !== -1 && deviceType) {
         const patch = {
           op: 'replace',
-          path: `/spec/template/spec/domain/devices/${deviceType}/${deviceIndex}/bootOrder`,
+          path: `/spec/template/spec/domain/devices/${deviceTypePathKey}/${deviceIndex}/bootOrder`,
           value: bootOrder - 1,
         };
         patches.push(patch);

--- a/src/utils/tests/patches.test.js
+++ b/src/utils/tests/patches.test.js
@@ -62,6 +62,7 @@ const storage = {
 
 const disk = {
   name: storageNoClass.name,
+  bootOrder: 3,
   disk: {
     bus: storageNoClass.bus,
   },
@@ -151,6 +152,7 @@ const podNic = {
 
 const intface = {
   name: nic.name,
+  bootOrder: 3,
   macAddress: nic.mac,
   model: nic.model,
   bridge: {},
@@ -378,34 +380,39 @@ describe('utils.js tests', () => {
       expectCpuMemWrapped(vm, '3', '4G', '3', '4G');
     });
   });
-  it('Add Nic patch', () => {
+  it('Add Nic patch - VM without networks', () => {
     const vmWithoutNetworks = getVM(false);
 
-    let patch = getAddNicPatch(vmWithoutNetworks, nic);
+    const patch = getAddNicPatch(vmWithoutNetworks, nic);
     expect(patch).toHaveLength(2);
     comparePatch(patch[0], '/spec/template/spec/domain/devices/interfaces/0', intface);
     comparePatch(patch[1], '/spec/template/spec/networks', [network]);
-
+  });
+  it('AddNicPatch - VM without interfaces', () => {
     const vmWithoutInterfaces = getVM(false);
     delete vmWithoutInterfaces.spec.template.spec.domain.devices.interfaces;
     vmWithoutInterfaces.spec.template.spec.networks = {};
 
-    patch = getAddNicPatch(vmWithoutInterfaces, nic);
+    const patch = getAddNicPatch(vmWithoutInterfaces, nic);
     expect(patch).toHaveLength(2);
     comparePatch(patch[0], '/spec/template/spec/domain/devices/interfaces', [intface]);
     comparePatch(patch[1], '/spec/template/spec/networks/0', network);
-
+  });
+  it('AddNicPatch - VM without networks or MAC', () => {
+    const vmWithoutNetworks = getVM(false);
     const nicWithoutMac = cloneDeep(nic);
     delete nicWithoutMac.mac;
     const intfaceWithoutMac = cloneDeep(intface);
     delete intfaceWithoutMac.macAddress;
 
-    patch = getAddNicPatch(vmWithoutNetworks, nicWithoutMac);
+    const patch = getAddNicPatch(vmWithoutNetworks, nicWithoutMac);
     expect(patch).toHaveLength(2);
     comparePatch(patch[0], '/spec/template/spec/domain/devices/interfaces/0', intfaceWithoutMac);
     comparePatch(patch[1], '/spec/template/spec/networks', [network]);
-
-    patch = getAddNicPatch(vmWithoutNetworks, podNic);
+  });
+  it('AddNicPatch - VM without networks using podNic', () => {
+    const vmWithoutNetworks = getVM(false);
+    const patch = getAddNicPatch(vmWithoutNetworks, podNic);
     expect(patch).toHaveLength(2);
     comparePatch(patch[0], '/spec/template/spec/domain/devices/interfaces/0', intface);
     comparePatch(patch[1], '/spec/template/spec/networks', [podNetwork]);


### PR DESCRIPTION
This PR is to add a boot order component to the VM details dialog. Editing functionality will be added in a separate PR in the future.

Depends on: https://github.com/kubevirt/web-ui/pull/207