### PR TITLE
shorten URL in VmTemplateDetail and refactor TemplateSource

### DIFF
--- a/src/components/Details/Url/Url.js
+++ b/src/components/Details/Url/Url.js
@@ -1,0 +1,66 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { parseUrl } from '../../../utils';
+
+const ELIPSIS = '…';
+
+const elipsizeLeft = word => `${ELIPSIS}${word}`;
+
+const resolveOrigin = ({ hostname, origin, port }, maxHostnameParts) => {
+  const hostnameParts = hostname.split('.');
+  if (hostnameParts.length <= maxHostnameParts) {
+    return origin;
+  }
+
+  const resolvedHostname = hostnameParts.slice(hostnameParts.length - maxHostnameParts).join('.');
+  const resolvedPort = port ? `:${port}` : '';
+
+  return `${elipsizeLeft(resolvedHostname)}${resolvedPort}`;
+};
+
+const resolvePathname = ({ pathname }, maxPathnameParts) => {
+  const pathnameParts = pathname.split('/').filter(part => part);
+  if (pathnameParts.length <= maxPathnameParts) {
+    return pathname;
+  }
+
+  const resolvedPathname = pathnameParts.slice(pathnameParts.length - maxPathnameParts).join('/');
+  return `/${elipsizeLeft(`/${resolvedPathname}`)}`;
+};
+
+const resolveUrl = ({ urlObj, maxHostnameParts, maxPathnameParts }) => {
+  const { search, hash } = urlObj;
+
+  const resolvedOrigin = resolveOrigin(urlObj, maxHostnameParts);
+  const resolvedPathname = resolvePathname(urlObj, maxPathnameParts);
+  const resolvedSearchHash = search.length > 0 || hash.length > 0 ? ELIPSIS : '';
+
+  return `${resolvedOrigin}${resolvedPathname}${resolvedSearchHash}`;
+};
+
+export const Url = ({ url, short, maxHostnameParts, maxPathnameParts }) => {
+  const urlObj = short ? parseUrl(url) : undefined;
+
+  const resolvedUrl = urlObj ? resolveUrl({ urlObj, maxHostnameParts, maxPathnameParts }) : url;
+  const resolvedTitle = resolvedUrl === url ? undefined : url;
+
+  return (
+    <a href={url} title={resolvedTitle}>
+      {resolvedUrl}
+    </a>
+  );
+};
+
+Url.propTypes = {
+  url: PropTypes.string.isRequired,
+  short: PropTypes.bool,
+  maxHostnameParts: PropTypes.number,
+  maxPathnameParts: PropTypes.number,
+};
+
+Url.defaultProps = {
+  short: false,
+  maxHostnameParts: 3,
+  maxPathnameParts: 1,
+};

--- a/src/components/Details/Url/fixtures/Url.fixture.js
+++ b/src/components/Details/Url/fixtures/Url.fixture.js
@@ -1,0 +1,20 @@
+import { Url } from '../Url';
+import { LONG_ISO_URL } from '../../../../tests/mocks/user_template/url.mock';
+
+export default [
+  {
+    name: 'long',
+    component: Url,
+    props: {
+      url: LONG_ISO_URL,
+    },
+  },
+  {
+    name: 'short',
+    component: Url,
+    props: {
+      url: LONG_ISO_URL,
+      short: true,
+    },
+  },
+];

--- a/src/components/Details/Url/index.js
+++ b/src/components/Details/Url/index.js
@@ -1,0 +1,1 @@
+export * from './Url';

--- a/src/components/Details/Url/tests/Url.test.js
+++ b/src/components/Details/Url/tests/Url.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { Url } from '..';
+
+import { default as urlFixtures } from '../fixtures/Url.fixture';
+
+const testUrl = ({ props }) => <Url {...props} />;
+
+describe('<Url />', () => {
+  it('renders correctly', () => {
+    urlFixtures.forEach(fixture => {
+      const component = mount(testUrl(fixture));
+      expect(component).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/Details/Url/tests/__snapshots__/Url.test.js.snap
+++ b/src/components/Details/Url/tests/__snapshots__/Url.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Url /> renders correctly 1`] = `
+<Url
+  maxHostnameParts={3}
+  maxPathnameParts={1}
+  short={false}
+  url="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
+>
+  <a
+    href="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
+  >
+    http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here
+  </a>
+</Url>
+`;
+
+exports[`<Url /> renders correctly 2`] = `
+<Url
+  maxHostnameParts={3}
+  maxPathnameParts={1}
+  short={true}
+  url="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
+>
+  <a
+    href="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
+    title="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
+  >
+    …mountain.all-images.cz/…/dromaeosauridae.iso…
+  </a>
+</Url>
+`;

--- a/src/components/Details/VmTemplateDetails/tests/__snapshots__/VmTemplateDetails.test.js.snap
+++ b/src/components/Details/VmTemplateDetails/tests/__snapshots__/VmTemplateDetails.test.js.snap
@@ -87,7 +87,9 @@ exports[`<VmTemplateDetails /> renders container correctly 1`] = `
             </dt>
             <dd>
               <div
+                class=""
                 id="myproject-container-template-cloud-init-type"
+                title="fooContainer"
               >
                 Container
               </div>
@@ -219,6 +221,7 @@ exports[`<VmTemplateDetails /> renders pxe correctly 1`] = `
             </dt>
             <dd>
               <div
+                class=""
                 id="myproject-pxe-template-dv-type"
               >
                 PXE
@@ -345,7 +348,9 @@ exports[`<VmTemplateDetails /> renders url correctly 1`] = `
             </dt>
             <dd>
               <div
+                class=""
                 id="myproject-url-template-type"
+                title="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
               >
                 URL
               </div>
@@ -353,7 +358,12 @@ exports[`<VmTemplateDetails /> renders url correctly 1`] = `
                 class="kubevirt-template-source__source"
                 id="myproject-url-template-source"
               >
-                fooUrl
+                <a
+                  href="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
+                  title="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
+                >
+                  …mountain.all-images.cz/…/dromaeosauridae.iso…
+                </a>
               </div>
             </dd>
             <dt>

--- a/src/components/TemplateSource/TemplateSource.js
+++ b/src/components/TemplateSource/TemplateSource.js
@@ -1,61 +1,87 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { OverlayTrigger, Tooltip } from 'patternfly-react';
 
+import { Url } from '../Details/Url';
 import { getTemplateProvisionSource } from '../../utils/templates';
-import { PROVISION_SOURCE_PXE } from '../../constants';
+import { PROVISION_SOURCE_URL } from '../../constants';
 import { getName, getNamespace } from '../../utils/selectors';
 import { prefixedId } from '../../utils/utils';
 
-const tooltip = (id, source) => <Tooltip id={id}>{source}</Tooltip>;
+const Type = ({ type, source, id, isInline }) => (
+  <div id={id} title={source} className={isInline ? 'kubevirt-template-source__overlay' : ''}>
+    {type}
+  </div>
+);
 
-export const TemplateSource = ({ template, tooltipPlacement, dataVolumes, detailed }) => {
-  const provisionSource = getTemplateProvisionSource(template, dataVolumes);
-  if (provisionSource) {
-    const { type, source } = provisionSource;
-    const id = prefixedId(getNamespace(template), getName(template));
-    const typeElem = <div id={prefixedId(id, 'type')}>{type}</div>;
+Type.propTypes = {
+  type: PropTypes.string.isRequired,
+  source: PropTypes.string,
+  id: PropTypes.string,
+  isInline: PropTypes.bool,
+};
 
-    if (type === PROVISION_SOURCE_PXE) {
-      return typeElem;
-    }
+Type.defaultProps = {
+  source: undefined,
+  id: undefined,
+  isInline: false,
+};
 
-    if (detailed) {
-      return (
-        <React.Fragment>
-          {typeElem}
-          <div id={prefixedId(id, 'source')} className="kubevirt-template-source__source">
-            {source}
-          </div>
-        </React.Fragment>
-      );
-    }
-
-    return (
-      <div className="kubevirt-template-source__overlay">
-        <OverlayTrigger
-          overlay={tooltip(id, source)}
-          placement={tooltipPlacement}
-          trigger={['hover', 'focus']}
-          rootClose={false}
-        >
-          {typeElem}
-        </OverlayTrigger>
-      </div>
-    );
+const Source = ({ type, source, id }) => {
+  if (!source) {
+    return null;
   }
-  return '---';
+
+  const sourceElem = type === PROVISION_SOURCE_URL ? <Url url={source} short /> : source;
+
+  return (
+    <div id={id} className="kubevirt-template-source__source">
+      {sourceElem}
+    </div>
+  );
+};
+
+Source.propTypes = {
+  type: PropTypes.string.isRequired,
+  source: PropTypes.string,
+  id: PropTypes.string,
+};
+
+Source.defaultProps = {
+  source: undefined,
+  id: undefined,
+};
+
+export const TemplateSource = ({ template, dataVolumes, detailed }) => {
+  const provisionSource = getTemplateProvisionSource(template, dataVolumes);
+
+  if (!provisionSource) {
+    return '---';
+  }
+
+  const { type, source } = provisionSource;
+  const id = prefixedId(getNamespace(template), getName(template));
+  const typeId = prefixedId(id, 'type');
+  const sourceId = prefixedId(id, 'source');
+
+  if (!detailed) {
+    return <Type id={typeId} type={type} source={source} isInline />;
+  }
+
+  return (
+    <React.Fragment>
+      <Type id={typeId} type={type} source={source} />
+      <Source id={sourceId} type={type} source={source} />
+    </React.Fragment>
+  );
 };
 
 TemplateSource.propTypes = {
   template: PropTypes.object.isRequired,
-  tooltipPlacement: PropTypes.string,
   dataVolumes: PropTypes.array,
   detailed: PropTypes.bool,
 };
 
 TemplateSource.defaultProps = {
-  tooltipPlacement: 'top',
   dataVolumes: [],
   detailed: false,
 };

--- a/src/components/TemplateSource/fixtures/TemplateSource.fixture.js
+++ b/src/components/TemplateSource/fixtures/TemplateSource.fixture.js
@@ -3,11 +3,20 @@ import { urlTemplate, urlTemplateDataVolume } from '../../../tests/mocks/user_te
 
 export default [
   {
+    name: 'inline',
     component: TemplateSource,
     props: {
       template: urlTemplate,
-      tooltipPlacement: 'bottom',
       dataVolumes: [urlTemplateDataVolume],
+    },
+  },
+  {
+    name: 'detailed',
+    component: TemplateSource,
+    props: {
+      template: urlTemplate,
+      dataVolumes: [urlTemplateDataVolume],
+      detailed: true,
     },
   },
 ];

--- a/src/components/TemplateSource/tests/TemplateSource.test.js
+++ b/src/components/TemplateSource/tests/TemplateSource.test.js
@@ -1,34 +1,42 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { OverlayTrigger } from 'patternfly-react';
 
 import { TemplateSource } from '../TemplateSource';
-import { containerTemplate, urlTemplate, pxeTemplate } from '../../../tests/mocks/user_template';
-import { urlTemplateDataVolume } from '../../../tests/mocks/user_template/url.mock';
+import { default as urlFixtures } from '../fixtures/TemplateSource.fixture';
+import { containerTemplate, pxeTemplate } from '../../../tests/mocks/user_template';
 
-const testTemplateSource = template => <TemplateSource template={template} />;
+const testTemplateSource = ({ props }) => <TemplateSource {...props} />;
 
 describe('<TemplateSource />', () => {
   it('renders correctly', () => {
-    const component = shallow(testTemplateSource(containerTemplate));
-    expect(component).toMatchSnapshot();
-  });
-
-  it('renders overlay for URL and Registry, not for PXE', () => {
-    const component = shallow(testTemplateSource(containerTemplate));
-    expect(component.find(OverlayTrigger).exists()).toBeTruthy();
-
-    component.setProps({
-      template: pxeTemplate,
+    const tests = [
+      ...urlFixtures,
+      {
+        props: {
+          template: pxeTemplate,
+        },
+      },
+      {
+        props: {
+          template: pxeTemplate,
+          detailed: true,
+        },
+      },
+      {
+        props: {
+          template: containerTemplate,
+        },
+      },
+      {
+        props: {
+          template: containerTemplate,
+          detailed: true,
+        },
+      },
+    ];
+    tests.forEach(fixture => {
+      const component = shallow(testTemplateSource(fixture));
+      expect(component).toMatchSnapshot();
     });
-
-    expect(component.find(OverlayTrigger).exists()).toBeFalsy();
-
-    component.setProps({
-      template: urlTemplate,
-      dataVolumes: [urlTemplateDataVolume],
-    });
-
-    expect(component.find(OverlayTrigger).exists()).toBeTruthy();
   });
 });

--- a/src/components/TemplateSource/tests/__snapshots__/TemplateSource.test.js.snap
+++ b/src/components/TemplateSource/tests/__snapshots__/TemplateSource.test.js.snap
@@ -1,34 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<TemplateSource /> renders correctly 1`] = `
-<div
-  className="kubevirt-template-source__overlay"
->
-  <OverlayTrigger
-    defaultOverlayShown={false}
-    overlay={
-      <Tooltip
-        bsClass="tooltip"
-        id="myproject-container-template"
-        placement="right"
-      >
-        fooContainer
-      </Tooltip>
-    }
-    placement="top"
-    rootClose={false}
-    trigger={
-      Array [
-        "hover",
-        "focus",
-      ]
-    }
-  >
-    <div
-      id="myproject-container-template-type"
-    >
-      Container
-    </div>
-  </OverlayTrigger>
-</div>
+<Type
+  id="myproject-url-template-type"
+  isInline={true}
+  source="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
+  type="URL"
+/>
+`;
+
+exports[`<TemplateSource /> renders correctly 2`] = `
+<Fragment>
+  <Type
+    id="myproject-url-template-type"
+    isInline={false}
+    source="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
+    type="URL"
+  />
+  <Source
+    id="myproject-url-template-source"
+    source="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
+    type="URL"
+  />
+</Fragment>
+`;
+
+exports[`<TemplateSource /> renders correctly 3`] = `
+<Type
+  id="myproject-pxe-template-type"
+  isInline={true}
+  type="PXE"
+/>
+`;
+
+exports[`<TemplateSource /> renders correctly 4`] = `
+<Fragment>
+  <Type
+    id="myproject-pxe-template-type"
+    isInline={false}
+    type="PXE"
+  />
+  <Source
+    id="myproject-pxe-template-source"
+    type="PXE"
+  />
+</Fragment>
+`;
+
+exports[`<TemplateSource /> renders correctly 5`] = `
+<Type
+  id="myproject-container-template-type"
+  isInline={true}
+  source="fooContainer"
+  type="Container"
+/>
+`;
+
+exports[`<TemplateSource /> renders correctly 6`] = `
+<Fragment>
+  <Type
+    id="myproject-container-template-type"
+    isInline={false}
+    source="fooContainer"
+    type="Container"
+  />
+  <Source
+    id="myproject-container-template-source"
+    source="fooContainer"
+    type="Container"
+  />
+</Fragment>
 `;

--- a/src/tests/mocks/user_template/url-flavor.mock.js
+++ b/src/tests/mocks/user_template/url-flavor.mock.js
@@ -1,4 +1,5 @@
 import { LABEL_USED_TEMPLATE_NAME, LABEL_USED_TEMPLATE_NAMESPACE } from '../../../constants';
+import { LONG_ISO_URL } from './url.mock';
 
 export const urlCustomFlavorTemplate = {
   apiVersion: 'template.openshift.io/v1',
@@ -44,7 +45,7 @@ export const urlCustomFlavorTemplate = {
               },
               source: {
                 http: {
-                  url: 'fooUrl',
+                  url: LONG_ISO_URL,
                 },
               },
             },

--- a/src/tests/mocks/user_template/url-nonetwork.mock.js
+++ b/src/tests/mocks/user_template/url-nonetwork.mock.js
@@ -1,4 +1,5 @@
 import { LABEL_USED_TEMPLATE_NAME, LABEL_USED_TEMPLATE_NAMESPACE } from '../../../constants';
+import { LONG_ISO_URL } from './url.mock';
 
 export const urlNoNetworkTemplate = {
   apiVersion: 'template.openshift.io/v1',
@@ -44,7 +45,7 @@ export const urlNoNetworkTemplate = {
               },
               source: {
                 http: {
-                  url: 'fooUrl',
+                  url: LONG_ISO_URL,
                 },
               },
             },

--- a/src/tests/mocks/user_template/url.mock.js
+++ b/src/tests/mocks/user_template/url.mock.js
@@ -1,5 +1,8 @@
 import { LABEL_USED_TEMPLATE_NAME, LABEL_USED_TEMPLATE_NAMESPACE } from '../../../constants';
 
+export const LONG_ISO_URL =
+  'http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here';
+
 export const urlTemplate = {
   apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
@@ -104,7 +107,7 @@ export const urlTemplateDataVolume = {
     },
     source: {
       http: {
-        url: 'fooUrl',
+        url: LONG_ISO_URL,
       },
     },
   },

--- a/src/utils/tests/templates.test.js
+++ b/src/utils/tests/templates.test.js
@@ -38,7 +38,7 @@ import {
   urlNoNetworkTemplate,
 } from '../../tests/mocks/user_template';
 import { getNamespace } from '../selectors';
-import { urlTemplateDataVolume } from '../../tests/mocks/user_template/url.mock';
+import { urlTemplateDataVolume, LONG_ISO_URL } from '../../tests/mocks/user_template/url.mock';
 
 const templates = [...baseTemplates, ...userTemplates];
 
@@ -117,7 +117,7 @@ describe('templates.js', () => {
   it('getTemplateProvisionSource returns proper template provision source', () => {
     expect(getTemplateProvisionSource(urlTemplate, [urlTemplateDataVolume])).toEqual({
       type: PROVISION_SOURCE_URL,
-      source: 'fooUrl',
+      source: LONG_ISO_URL,
     });
 
     expect(getTemplateProvisionSource(containerTemplate)).toEqual({

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -4,6 +4,14 @@ export function prefixedId(idPrefix, id) {
   return idPrefix && id ? `${idPrefix}-${id}` : null;
 }
 
+export const parseUrl = url => {
+  try {
+    return new URL(url);
+  } catch (e) {
+    return null;
+  }
+};
+
 export const getSequence = (from, to) => Array.from({ length: to - from + 1 }, (v, i) => i + from);
 
 export const setNativeValue = (element, value) => {

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -12,6 +12,9 @@ import {
   START_WHITESPACE_ERROR,
   END_WHITESPACE_ERROR,
 } from './strings';
+
+import { parseUrl } from './utils';
+
 import { VALIDATION_ERROR_TYPE } from '../constants';
 
 export const isPositiveNumber = value => value && value.match(/^[1-9]\d*$/);
@@ -60,12 +63,8 @@ export const validateURL = value => {
   if (trimEnd(value).length !== value.length) {
     return getValidationObject(END_WHITESPACE_ERROR);
   }
-  try {
-    new URL(value);
-    return null;
-  } catch {
-    return getValidationObject(URL_INVALID_ERROR);
-  }
+
+  return parseUrl(value) ? null : getValidationObject(URL_INVALID_ERROR);
 };
 
 export const validateContainer = value => {


### PR DESCRIPTION
Fixes #217 

Shortens url. The href and tooltip contain the original url.

#### Transformations:

base url: http://merlin.fit.vutbr.cz/mirrors/centos/7.6.1810/isos/x86_64/CentOS-7-x86_64-Minimal-1810.iso

![a](https://user-images.githubusercontent.com/3648838/53021377-60117000-3459-11e9-9aac-8d2ea788bfb9.png)

base url: http://fit.vutbr.cz/mirrors/centos/7.6.1810/isos/x86_64/CentOS-7-x86_64-Minimal-1810.iso

![b](https://user-images.githubusercontent.com/3648838/53021600-d8783100-3459-11e9-8fa2-91f1789e021b.png)

base url: http://merlin.fit.vutbr.cz/CentOS-7-x86_64-Minimal-1810.iso?a=5#here

![e](https://user-images.githubusercontent.com/3648838/53021908-808dfa00-345a-11e9-9926-37c5b083d82c.png)


One disadvantage is that the elipsis can appear 3 times:  [...sub.hostname.end/.../final-part...]() 
 The last bit for parameters. 

@andybraren What do you think? 
