### PR TITLE
VmCreateDialog: display JSONs on error in ResultsTab

### DIFF
--- a/sass/components/Wizard/create-vm-wizard.scss
+++ b/sass/components/Wizard/create-vm-wizard.scss
@@ -10,7 +10,7 @@
   margin-top: 2em;
 }
 
-.kubevirt-create-vm-wizard__result-success {
+.kubevirt-create-vm-wizard__result-tab-row {
   text-align: left;
 }
 

--- a/src/components/Wizard/CreateVmWizard/ResultTab.js
+++ b/src/components/Wizard/CreateVmWizard/ResultTab.js
@@ -1,46 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Alert } from 'patternfly-react';
 
 import { Loading } from '../../Loading';
 
-const getCreationText = createTemplate => `Creation of VM ${createTemplate ? 'Template ' : ''}`;
+const getCreationText = (state, createTemplate) => `Creation of VM ${createTemplate ? 'Template ' : ''}${state}`;
 
-export const ResultTab = ({ results, success, createTemplate }) => {
-  let value;
-  const loadingText = `${getCreationText(createTemplate)}in progress`;
-  const successText = `${getCreationText(createTemplate)}was successful`;
-  if (success == null) {
-    value = <Loading text={loadingText} />;
-  } else if (success) {
-    value = (
-      <div className="wizard-pf-complete blank-slate-pf" key="success">
-        <div className="wizard-pf-success-icon">
-          <span className="glyphicon glyphicon-ok-circle" />
-        </div>
-        <h3 className="blank-slate-pf-main-action">{successText}</h3>
-        {results.map((result, index) => (
-          <pre key={index} className="blank-slate-pf-secondary-action kubevirt-create-vm-wizard__result-success">
-            {JSON.stringify(result, null, 1)}
-          </pre>
-        ))}
-      </div>
-    );
-  } else {
-    value = results.map((result, index) => <Alert key={index}>{result}</Alert>);
+export const ResultTab = ({ isSuccessful, isCreateTemplate, children }) => {
+  if (isSuccessful == null) {
+    return <Loading key="progress" text={getCreationText('in progress', isCreateTemplate)} />;
   }
+  const state = isSuccessful ? 'was successful' : 'failed';
+  const icon = isSuccessful ? 'pficon-ok' : 'pficon-error-circle-o';
 
-  return value;
+  return (
+    <div className="wizard-pf-complete blank-slate-pf" key="success">
+      <div className="wizard-pf-success-icon">
+        <span className={`pficon ${icon}`} />
+      </div>
+      <h3 className="blank-slate-pf-main-action">{getCreationText(state, isCreateTemplate)}</h3>
+      {children}
+    </div>
+  );
 };
 
 ResultTab.defaultProps = {
-  results: [],
-  success: null,
-  createTemplate: false,
+  children: null,
+  isSuccessful: null,
+  isCreateTemplate: false,
 };
 
 ResultTab.propTypes = {
-  results: PropTypes.array,
-  success: PropTypes.bool,
-  createTemplate: PropTypes.bool,
+  children: PropTypes.node,
+  isSuccessful: PropTypes.bool,
+  isCreateTemplate: PropTypes.bool,
 };

--- a/src/components/Wizard/CreateVmWizard/ResultTabRow.js
+++ b/src/components/Wizard/CreateVmWizard/ResultTabRow.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ExpandCollapse } from 'patternfly-react';
+
+export const ResultTabRow = ({ title, content, expanded }) => {
+  const resolvedContent = typeof content === 'object' ? JSON.stringify(content, null, 1) : content;
+
+  return (
+    <ExpandCollapse textExpanded={title} textCollapsed={title} expanded={expanded}>
+      <pre className="blank-slate-pf-secondary-action kubevirt-create-vm-wizard__result-tab-row">{resolvedContent}</pre>
+    </ExpandCollapse>
+  );
+};
+
+ResultTabRow.defaultProps = {
+  expanded: false,
+};
+
+ResultTabRow.propTypes = {
+  title: PropTypes.string.isRequired,
+  content: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+  expanded: PropTypes.bool,
+};

--- a/src/components/Wizard/CreateVmWizard/fixtures/ResultTab.fixture.js
+++ b/src/components/Wizard/CreateVmWizard/fixtures/ResultTab.fixture.js
@@ -5,24 +5,23 @@ export default [
     component: ResultTab,
     name: 'Loading',
     props: {
-      success: null,
-      results: null,
+      isSuccessful: null,
     },
   },
   {
     component: ResultTab,
     name: 'Error',
     props: {
-      success: false,
-      results: ['Failed'],
+      isSuccessful: false,
+      children: ['Error'],
     },
   },
   {
     component: ResultTab,
     name: 'Success',
     props: {
-      success: true,
-      results: ['Finished succesfully'],
+      isSuccessful: true,
+      children: ['Result'],
     },
   },
 ];

--- a/src/components/Wizard/CreateVmWizard/fixtures/ResultTabRow.fixture.js
+++ b/src/components/Wizard/CreateVmWizard/fixtures/ResultTabRow.fixture.js
@@ -1,0 +1,22 @@
+import { ResultTabRow } from '../ResultTabRow';
+import { cloudInitTestVm } from '../../../../tests/mocks/vm/cloudInitTestVm.mock';
+
+export default [
+  {
+    component: ResultTabRow,
+    name: 'Error',
+    props: {
+      title: 'Error',
+      content: 'Failed',
+      expanded: true,
+    },
+  },
+  {
+    component: ResultTabRow,
+    name: 'Success',
+    props: {
+      title: 'VirtualMachine myvm Detail',
+      content: cloudInitTestVm,
+    },
+  },
+];

--- a/src/components/Wizard/CreateVmWizard/strings.js
+++ b/src/components/Wizard/CreateVmWizard/strings.js
@@ -57,3 +57,7 @@ export const ATTACH_DISK_BUTTON = 'Attach Disk';
 export const CREATE_DISK_BUTTON = 'Create Disk';
 export const BOOTABLE_DISK = 'Bootable Disk';
 export const SELECT_BOOTABLE_DISK = '--- Select Bootable Disk ---';
+
+export const ERROR = 'Error';
+export const CREATED = 'created';
+export const NOT_CREATED = 'not created';

--- a/src/components/Wizard/CreateVmWizard/tests/ResultTab.test.js
+++ b/src/components/Wizard/CreateVmWizard/tests/ResultTab.test.js
@@ -2,20 +2,15 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import { ResultTab } from '../ResultTab';
+import { default as resultTabFixtures } from '../fixtures/ResultTab.fixture';
+
+const testResultTab = ({ props }) => <ResultTab {...props} />;
 
 describe('<ResultTab />', () => {
-  it('renders progress correctly', () => {
-    const component = shallow(<ResultTab success={null} results={null} />);
-    expect(component).toMatchSnapshot();
-  });
-
-  it('renders success correctly', () => {
-    const component = shallow(<ResultTab success results={['Created VM']} />);
-    expect(component).toMatchSnapshot();
-  });
-
-  it('renders fail correctly', () => {
-    const component = shallow(<ResultTab success={false} results={['Failed to create VM']} />);
-    expect(component).toMatchSnapshot();
+  it('renders correctly', () => {
+    resultTabFixtures.forEach(fixture => {
+      const component = shallow(testResultTab(fixture));
+      expect(component).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/Wizard/CreateVmWizard/tests/ResultTabRow.test.js
+++ b/src/components/Wizard/CreateVmWizard/tests/ResultTabRow.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { ResultTabRow } from '../ResultTabRow';
+import { default as resultTabRowFixtures } from '../fixtures/ResultTabRow.fixture';
+
+const testResultTab = ({ props }) => <ResultTabRow {...props} />;
+
+describe('<ResultTabRow />', () => {
+  it('renders correctly', () => {
+    resultTabRowFixtures.forEach(fixture => {
+      const component = shallow(testResultTab(fixture));
+      expect(component).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/Wizard/CreateVmWizard/tests/__snapshots__/ResultTab.test.js.snap
+++ b/src/components/Wizard/CreateVmWizard/tests/__snapshots__/ResultTab.test.js.snap
@@ -1,23 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ResultTab /> renders fail correctly 1`] = `
-<Alert
-  className=""
-  key="0"
-  onDismiss={null}
-  type="error"
->
-  Failed to create VM
-</Alert>
-`;
-
-exports[`<ResultTab /> renders progress correctly 1`] = `
+exports[`<ResultTab /> renders correctly 1`] = `
 <Loading
+  key="progress"
   text="Creation of VM in progress"
 />
 `;
 
-exports[`<ResultTab /> renders success correctly 1`] = `
+exports[`<ResultTab /> renders correctly 2`] = `
 <div
   className="wizard-pf-complete blank-slate-pf"
   key="success"
@@ -26,7 +16,28 @@ exports[`<ResultTab /> renders success correctly 1`] = `
     className="wizard-pf-success-icon"
   >
     <span
-      className="glyphicon glyphicon-ok-circle"
+      className="pficon pficon-error-circle-o"
+    />
+  </div>
+  <h3
+    className="blank-slate-pf-main-action"
+  >
+    Creation of VM failed
+  </h3>
+  Error
+</div>
+`;
+
+exports[`<ResultTab /> renders correctly 3`] = `
+<div
+  className="wizard-pf-complete blank-slate-pf"
+  key="success"
+>
+  <div
+    className="wizard-pf-success-icon"
+  >
+    <span
+      className="pficon pficon-ok"
     />
   </div>
   <h3
@@ -34,11 +45,6 @@ exports[`<ResultTab /> renders success correctly 1`] = `
   >
     Creation of VM was successful
   </h3>
-  <pre
-    className="blank-slate-pf-secondary-action kubevirt-create-vm-wizard__result-success"
-    key="0"
-  >
-    "Created VM"
-  </pre>
+  Result
 </div>
 `;

--- a/src/components/Wizard/CreateVmWizard/tests/__snapshots__/ResultTabRow.test.js.snap
+++ b/src/components/Wizard/CreateVmWizard/tests/__snapshots__/ResultTabRow.test.js.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ResultTabRow /> renders correctly 1`] = `
+<ExpandCollapse
+  align="left"
+  bordered={true}
+  className=""
+  expanded={true}
+  textCollapsed="Error"
+  textExpanded="Error"
+>
+  <pre
+    className="blank-slate-pf-secondary-action kubevirt-create-vm-wizard__result-tab-row"
+  >
+    Failed
+  </pre>
+</ExpandCollapse>
+`;
+
+exports[`<ResultTabRow /> renders correctly 2`] = `
+<ExpandCollapse
+  align="left"
+  bordered={true}
+  className=""
+  expanded={false}
+  textCollapsed="VirtualMachine myvm Detail"
+  textExpanded="VirtualMachine myvm Detail"
+>
+  <pre
+    className="blank-slate-pf-secondary-action kubevirt-create-vm-wizard__result-tab-row"
+  >
+    {
+ "apiVersion": "kubevirt.io/v1alpha3",
+ "kind": "VirtualMachine",
+ "metadata": {
+  "annotations": {
+   "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lacus nibh, convallis vel nunc id,tempus vulputate augue. Proin eget nisl vel ante tincidunt accumsan vel at elit. Fusce eget tincidunt sem. Fusce cursus orci vitae nisl hendrerit mollis. Nullam at nulla ut ipsum malesuada laoreet a sit amet est."
+  },
+  "labels": {
+   "flavor.template.cnv.io/small": "true",
+   "os.template.cnv.io/fedora29": "true",
+   "template.cnv.ui": "default_fedora-generic",
+   "workload.template.cnv.io/generic": "true"
+  },
+  "clusterName": "",
+  "creationTimestamp": "2018-11-06T14:32:07Z",
+  "generation": 1,
+  "name": "cloudinit-test-vm",
+  "namespace": "default",
+  "resourceVersion": "10390764",
+  "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/cloudinit-test-vm",
+  "uid": "bcc1d0b1-e1d0-11e8-82b4-54ee7586b9c3"
+ },
+ "spec": {
+  "running": false,
+  "template": {
+   "spec": {
+    "domain": {
+     "cpu": {
+      "cores": 2
+     },
+     "devices": {
+      "disks": [
+       {
+        "disk": {
+         "bus": "virtio"
+        },
+        "name": "rootdisk"
+       },
+       {
+        "disk": {
+         "bus": "virtio"
+        },
+        "name": "cloudinitdisk"
+       }
+      ],
+      "interfaces": [
+       {
+        "bridge": {},
+        "name": "eth0"
+       }
+      ],
+      "rng": {}
+     },
+     "resources": {
+      "requests": {
+       "memory": "2G"
+      }
+     }
+    },
+    "networks": [
+     {
+      "name": "eth0",
+      "pod": {}
+     }
+    ],
+    "terminationGracePeriodSeconds": 0,
+    "volumes": [
+     {
+      "name": "rootdisk",
+      "containerDisk": {
+       "image": "kubevirt/cirros-registry-disk-demo"
+      }
+     },
+     {
+      "name": "cloudinitdisk",
+      "cloudInitNoCloud": {
+       "userData": "#cloud-config\\nusers:\\n  - name: root\\n    ssh-authorized-keys: |-\\n      AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU\\n      GPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3\\n      Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XA\\n      t3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/En\\n      mZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbx\\n      NrRFi9wrf+M7Q==\\nhostname: cloudinit-test\\n"
+      }
+     }
+    ]
+   }
+  }
+ }
+}
+  </pre>
+</ExpandCollapse>
+`;


### PR DESCRIPTION
implements RFE: https://bugzilla.redhat.com/show_bug.cgi?id=1667988

Successful creation:

![a](https://user-images.githubusercontent.com/3648838/53118694-f58e2c00-354d-11e9-981f-d2e1a3bb949b.png)

Displays detail on click:

![b](https://user-images.githubusercontent.com/3648838/53118710-02ab1b00-354e-11e9-9591-b785af654029.png)
 
Failure (displays error by default):

![c](https://user-images.githubusercontent.com/3648838/53118736-10f93700-354e-11e9-9646-6d891bcc36eb.png)

Displays failed objects on click:

![d](https://user-images.githubusercontent.com/3648838/53118762-20788000-354e-11e9-9964-06002f66eebd.png)
