### PR TITLE
v2v: prefill Name and Description based on VMWare VM

### DIFF
--- a/src/components/Form/FormFactory.js
+++ b/src/components/Form/FormFactory.js
@@ -18,6 +18,7 @@ export const getFormElement = props => {
     value,
     title,
     onChange,
+    onFormChange,
     onBlur,
     choices,
     defaultValue,
@@ -82,6 +83,7 @@ export const getFormElement = props => {
       return (
         <CustomComponent
           onChange={onChange}
+          onFormChange={onFormChange}
           id={id}
           key={id}
           value={value || defaultValue}
@@ -138,16 +140,8 @@ export const validateForm = (formFields, formValues) => {
   return formValid;
 };
 
-const onChange = (formFields, formValues, value, key, onFormChange) => {
-  const newFormValues = {
-    ...formValues,
-    [key]: {
-      value,
-    },
-  };
-
+export const getFieldValidation = (changedField, value, newFormValues) => {
   let validation;
-  const changedField = formFields[key];
   if (changedField.required && String(value).trim().length === 0) {
     validation = getValidationObject(ERROR_IS_REQUIRED);
   } else if (changedField.validate) {
@@ -158,8 +152,20 @@ const onChange = (formFields, formValues, value, key, onFormChange) => {
     validation.message = `${changedField.title} ${validation.message}`;
   }
 
-  newFormValues[key].validation = validation;
+  return validation;
+};
 
+const onChange = (formFields, formValues, value, key, onFormChange) => {
+  const newFormValues = {
+    ...formValues,
+    [key]: {
+      value,
+    },
+  };
+
+  const changedField = formFields[key];
+  const validation = getFieldValidation(changedField, value, newFormValues);
+  newFormValues[key].validation = validation;
   const formValid = validateForm(formFields, newFormValues);
 
   if (changedField.onChange) {
@@ -187,6 +193,7 @@ const getFormGroups = ({ fields, fieldsValues, onFormChange, textPosition, label
         value,
         isControlled: true,
         onChange: newValue => onChange(fields, fieldsValues, newValue, key, onFormChange),
+        onFormChange,
         className: classNames(field.className, {
           'kubevirt-form-group__field--with-addendum': hasAddendum,
         }),

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -1,6 +1,13 @@
 export { Checkbox } from './Checkbox';
 export { Dropdown } from './Dropdown';
-export { FormFactory, ListFormFactory, InlineFormFactory, validateForm, getFormElement } from './FormFactory';
+export {
+  FormFactory,
+  ListFormFactory,
+  InlineFormFactory,
+  validateForm,
+  getFormElement,
+  getFieldValidation,
+} from './FormFactory';
 export { Integer } from './Integer';
 export { Text } from './Text';
 export { TextArea } from './TextArea';

--- a/src/components/Wizard/CreateVmWizard/constants.js
+++ b/src/components/Wizard/CreateVmWizard/constants.js
@@ -24,6 +24,8 @@ export const NETWORKS_TAB_KEY = 'network';
 export const STORAGE_TAB_KEY = 'storage';
 export const RESULT_TAB_KEY = 'result';
 
+export const BATCH_CHANGES_KEY = 'internalBatchChanges';
+
 // NetworksTab
 export const NETWORK_TYPE_MULTUS = 'multus';
 export const NETWORK_TYPE_POD = 'pod';

--- a/src/components/Wizard/CreateVmWizard/providers/VCenterVms.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VCenterVms.js
@@ -11,7 +11,10 @@ import { PROVIDER_SELECT_VM } from '../strings';
 import { NAMESPACE_KEY, PROVIDER_VMWARE_CONNECTION, PROVIDER_VMWARE_USER_PWD_AND_CHECK_KEY } from '../constants';
 import { settingsValue } from '../../../../k8s/selectors';
 
-const VCenterVms = ({ onChange, id, value, extraProps }) => {
+import VCenterVmsWithPrefill from './VCenterVmsWithPrefill';
+
+const VCenterVms = ({ onChange, onFormChange, id, value, extraProps, ...extra }) => {
+  // the "value" is name of selected VMWare VM
   const { WithResources, basicSettings } = extraProps;
 
   const v2vvmwareName = get(basicSettings, [
@@ -36,16 +39,6 @@ const VCenterVms = ({ onChange, id, value, extraProps }) => {
   };
   const resourceToProps = ({ v2vvmware }) => {
     const vms = get(v2vvmware, 'spec.vms');
-
-    // TODO: dummy use of VM detail. Will be finalized once the Conversion pod is ready.
-    // Reference: http://pubs.vmware.com/vsphere-60/topic/com.vmware.wssdk.apiref.doc/vim.VirtualMachine.html
-    (vms || []).forEach(vm => {
-      if (vm.detail && vm.detail.raw) {
-        const raw = JSON.parse(vm.detail.raw);
-        console.log('--- parsed raw VM: ', raw);
-      }
-    });
-
     let choices = [];
     if (vms) {
       choices = vms.map(vm => vm.name);
@@ -59,7 +52,13 @@ const VCenterVms = ({ onChange, id, value, extraProps }) => {
 
   return (
     <WithResources resourceMap={resourceMap} resourceToProps={resourceToProps}>
-      <Dropdown id={id} value={value} onChange={onChange} />
+      <VCenterVmsWithPrefill
+        id={id}
+        value={value}
+        onChange={onChange}
+        onFormChange={onFormChange}
+        basicSettings={basicSettings}
+      />
     </WithResources>
   );
 };
@@ -70,6 +69,7 @@ VCenterVms.defaultProps = {
 VCenterVms.propTypes = {
   onChange: PropTypes.func.isRequired,
   extraProps: PropTypes.object.isRequired,
+  onFormChange: PropTypes.func.isRequired,
   id: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 };

--- a/src/components/Wizard/CreateVmWizard/providers/VCenterVmsWithPrefill.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VCenterVmsWithPrefill.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { get } from 'lodash';
+
+import { Dropdown } from '../../../Form';
+import { settingsValue } from '../../../../k8s/selectors';
+
+import { BATCH_CHANGES_KEY, DESCRIPTION_KEY, NAME_KEY, PROVIDER_VMWARE_VM_KEY } from '../constants';
+
+class VCenterVmsWithPrefill extends React.Component {
+  state = {
+    lastName: undefined, // last prefilled VM name value
+    lastDescription: undefined,
+  };
+
+  prefillVmName(basicSettings, onFormChange, vmVmware) {
+    const value = get(vmVmware, ['Config', 'Name']);
+    const formName = settingsValue(basicSettings, NAME_KEY);
+    if (!formName || formName === this.state.lastName) {
+      if (this.state.lastName !== value) {
+        // avoid infinite loop
+        this.setState({ lastName: value });
+        return { value, target: NAME_KEY };
+      }
+    }
+    return undefined;
+  }
+
+  prefillVmDescription(basicSettings, onFormChange, vmVmware) {
+    const value = get(vmVmware, ['Config', 'Annotation']);
+    const formValue = settingsValue(basicSettings, DESCRIPTION_KEY);
+    if (!formValue || formValue === this.state.lastDescription) {
+      if (this.state.lastDescription !== value) {
+        // avoid infinite loop
+        this.setState({ lastDescription: value });
+        return { value, target: DESCRIPTION_KEY };
+      }
+    }
+    return undefined;
+  }
+
+  prefillValues(basicSettings, onFormChange, vmVmware) {
+    const result = [];
+
+    const namePair = this.prefillVmName(basicSettings, onFormChange, vmVmware);
+    if (namePair) {
+      result.push(namePair);
+    }
+
+    const descrPair = this.prefillVmDescription(basicSettings, onFormChange, vmVmware);
+    if (descrPair) {
+      result.push(descrPair);
+    }
+
+    if (result.length > 0) {
+      onFormChange({ value: result }, BATCH_CHANGES_KEY);
+    }
+  }
+
+  componentDidUpdate() {
+    const { onFormChange, v2vvmware, basicSettings } = this.props;
+
+    if (v2vvmware) {
+      const selectedVmName = settingsValue(basicSettings, PROVIDER_VMWARE_VM_KEY);
+      if (this.state.lastName !== selectedVmName) {
+        // just once
+        const vms = get(v2vvmware, 'spec.vms');
+        const vmWithDetail = (vms || []).find(vm => vm.name === selectedVmName && vm.detail && vm.detail.raw);
+        if (vmWithDetail) {
+          const vmVmware = JSON.parse(vmWithDetail.detail.raw);
+          this.prefillValues(basicSettings, onFormChange, vmVmware);
+        }
+      }
+    }
+  }
+
+  render() {
+    const { id, value, onChange, choices, disabled } = this.props;
+    return <Dropdown id={id} value={value} onChange={onChange} choices={choices} disabled={disabled} />;
+  }
+}
+VCenterVmsWithPrefill.defaultProps = {
+  value: undefined,
+  choices: [],
+  disabled: true,
+  v2vvmware: undefined,
+};
+VCenterVmsWithPrefill.propTypes = {
+  id: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onFormChange: PropTypes.func.isRequired,
+  basicSettings: PropTypes.object.isRequired,
+  v2vvmware: PropTypes.object,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  choices: PropTypes.array,
+  disabled: PropTypes.bool,
+};
+
+export default VCenterVmsWithPrefill;

--- a/src/components/Wizard/CreateVmWizard/providers/fixtures/VCenterVmsWithPrefill.fixture.js
+++ b/src/components/Wizard/CreateVmWizard/providers/fixtures/VCenterVmsWithPrefill.fixture.js
@@ -1,0 +1,1 @@
+// no content

--- a/src/components/Wizard/CreateVmWizard/providers/tests/VCenterVms.test.js
+++ b/src/components/Wizard/CreateVmWizard/providers/tests/VCenterVms.test.js
@@ -13,8 +13,15 @@ const extraProps = {
 describe('<VCenterVms /> for list of vCenter secrets', () => {
   it('renders correctly', () => {
     const onChange = jest.fn();
+    const onFormChange = jest.fn();
     const component = render(
-      <VCenterVms onChange={onChange} id="test-dropdown-id" value="test-vm1" extraProps={extraProps} />
+      <VCenterVms
+        onChange={onChange}
+        onFormChange={onFormChange}
+        id="test-dropdown-id"
+        value="test-vm1"
+        extraProps={extraProps}
+      />
     );
     expect(component).toMatchSnapshot();
   });

--- a/src/components/Wizard/CreateVmWizard/providers/tests/VCenterVmsWithPrefill.test.js
+++ b/src/components/Wizard/CreateVmWizard/providers/tests/VCenterVmsWithPrefill.test.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme/build';
+
+import { basicSettingsImportVmwareNewConnection } from '../../../../../tests/forms_mocks/basicSettings.mock';
+
+import VCenterVmsWithPrefill from '../VCenterVmsWithPrefill';
+import { BATCH_CHANGES_KEY, PROVIDER_VMWARE_VM_KEY, NAME_KEY, DESCRIPTION_KEY } from '../../constants';
+
+const props = {
+  id: 'my-id',
+  value: 'vm-name',
+  choices: ['one-vm', 'vm-name'],
+  basicSettings: basicSettingsImportVmwareNewConnection,
+};
+props.basicSettings[PROVIDER_VMWARE_VM_KEY] = {
+  value: 'vm-name',
+};
+
+const v2vvmware = {
+  spec: {
+    vms: [
+      {
+        name: 'one-vm',
+      },
+      {
+        name: 'unknown-vm',
+      },
+      {
+        name: 'vm-name',
+        detail: {
+          raw: JSON.stringify({
+            Config: {
+              Name: 'vm-name',
+              Annotation: 'My description',
+            },
+          }),
+        },
+      },
+    ],
+  },
+};
+
+describe('<VCenterVmsWithPrefill />', () => {
+  it('renders correctly', () => {
+    const onChange = jest.fn();
+    const onFormChange = jest.fn();
+    const wrapper = shallow(<VCenterVmsWithPrefill {...props} onChange={onChange} onFormChange={onFormChange} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('does prefill', () => {
+    const onChange = jest.fn();
+    const onFormChange = jest.fn();
+    const wrapper = mount(<VCenterVmsWithPrefill {...props} onChange={onChange} onFormChange={onFormChange} />);
+    expect(wrapper).toMatchSnapshot();
+    expect(onChange.mock.calls).toHaveLength(0);
+    expect(onFormChange.mock.calls).toHaveLength(0);
+
+    wrapper.setProps({ v2vvmware }); // force componentDidUpdate
+    expect(onChange.mock.calls).toHaveLength(0);
+    expect(onFormChange.mock.calls).toHaveLength(1);
+    expect(onFormChange.mock.calls[0][1]).toBe(BATCH_CHANGES_KEY);
+    expect(onFormChange.mock.calls[0][0].value[0]).toEqual({ value: 'My description', target: DESCRIPTION_KEY }); // name is skipped as it was provided by the user
+
+    const newBasicSettings = props.basicSettings;
+    newBasicSettings[NAME_KEY] = '';
+    wrapper.setProps({ basicSettings: newBasicSettings });
+    expect(onFormChange.mock.calls).toHaveLength(2);
+    expect(onFormChange.mock.calls[1][1]).toBe(BATCH_CHANGES_KEY);
+    expect(onFormChange.mock.calls[1][0].value[0]).toEqual({ value: 'vm-name', target: NAME_KEY }); // description is skipped as it is equal with former run
+  });
+});

--- a/src/components/Wizard/CreateVmWizard/providers/tests/__snapshots__/VCenterVmsWithPrefill.test.js.snap
+++ b/src/components/Wizard/CreateVmWizard/providers/tests/__snapshots__/VCenterVmsWithPrefill.test.js.snap
@@ -1,0 +1,293 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<VCenterVmsWithPrefill /> does prefill 1`] = `
+<VCenterVmsWithPrefill
+  basicSettings={
+    Object {
+      "flavor": Object {
+        "value": "small",
+      },
+      "name": Object {
+        "value": "name",
+      },
+      "namespace": Object {
+        "value": "default",
+      },
+      "operatingSystem": Object {
+        "value": Object {
+          "id": "rhel7.0",
+          "name": "Red Hat Enterprise Linux 7.0",
+        },
+      },
+      "provider": Object {
+        "value": "VMWare",
+      },
+      "provisionSourceType": Object {
+        "value": "Import",
+      },
+      "rememberVmwareCredentials": Object {
+        "value": true,
+      },
+      "vCenterInstance": Object {
+        "value": "Connect to New Instance",
+      },
+      "vmwareURL": Object {
+        "value": "my.domain.com",
+      },
+      "vmwareUserName": Object {
+        "value": "username",
+      },
+      "vmwareUserPwdCheck": Object {
+        "value": Object {
+          "vmwareConnection": Object {
+            "V2VVmwareName": "v2vvmware-object-name",
+          },
+          "vmwareUserPwd": "password",
+        },
+      },
+      "vmwareVm": Object {
+        "value": "vm-name",
+      },
+      "workloadProfile": Object {
+        "value": "generic",
+      },
+    }
+  }
+  choices={
+    Array [
+      "one-vm",
+      "vm-name",
+    ]
+  }
+  disabled={true}
+  id="my-id"
+  onChange={[MockFunction]}
+  onFormChange={[MockFunction]}
+  value="vm-name"
+>
+  <Dropdown
+    choices={
+      Array [
+        "one-vm",
+        "vm-name",
+      ]
+    }
+    disabled={true}
+    id="my-id"
+    onChange={[MockFunction]}
+    value="vm-name"
+    withTooltips={false}
+  >
+    <ButtonGroup
+      block={false}
+      bsClass="btn-group"
+      justified={true}
+      key="my-id"
+      vertical={false}
+    >
+      <div
+        className="btn-group btn-group-justified"
+      >
+        <DropdownButton
+          bsStyle="default"
+          className="kubevirt-dropdown"
+          disabled={true}
+          id="my-id"
+          onSelect={[MockFunction]}
+          title="vm-name"
+        >
+          <DropdownButton
+            bsStyle="default"
+            className="kubevirt-dropdown"
+            disabled={true}
+            id="my-id"
+            onSelect={[MockFunction]}
+            title="vm-name"
+          >
+            <Uncontrolled(Dropdown)
+              bsStyle="default"
+              disabled={true}
+              id="my-id"
+              onSelect={[MockFunction]}
+            >
+              <Dropdown
+                bsClass="dropdown"
+                bsStyle="default"
+                componentClass={[Function]}
+                disabled={true}
+                id="my-id"
+                onSelect={[MockFunction]}
+                onToggle={[Function]}
+              >
+                <ButtonGroup
+                  block={false}
+                  bsClass="btn-group"
+                  bsStyle="default"
+                  className="dropdown disabled"
+                  justified={false}
+                  vertical={false}
+                >
+                  <div
+                    className="dropdown disabled btn-group btn-group-default"
+                  >
+                    <DropdownToggle
+                      bsClass="dropdown-toggle"
+                      bsRole="toggle"
+                      bsStyle="default"
+                      className="kubevirt-dropdown"
+                      disabled={true}
+                      id="my-id"
+                      key=".0"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      open={false}
+                      useAnchor={false}
+                    >
+                      <Button
+                        active={false}
+                        aria-expanded={false}
+                        aria-haspopup={true}
+                        block={false}
+                        bsClass="btn"
+                        bsStyle="default"
+                        className="kubevirt-dropdown dropdown-toggle"
+                        disabled={true}
+                        id="my-id"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="button"
+                      >
+                        <button
+                          aria-expanded={false}
+                          aria-haspopup={true}
+                          className="kubevirt-dropdown dropdown-toggle btn btn-default"
+                          disabled={true}
+                          id="my-id"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="button"
+                          type="button"
+                        >
+                          vm-name
+                           
+                          <span
+                            className="caret"
+                          />
+                        </button>
+                      </Button>
+                    </DropdownToggle>
+                    <DropdownMenu
+                      bsClass="dropdown-menu"
+                      bsRole="menu"
+                      key=".1"
+                      labelledBy="my-id"
+                      onClose={[Function]}
+                      onSelect={[Function]}
+                      pullRight={false}
+                    >
+                      <RootCloseWrapper
+                        disabled={true}
+                        event="click"
+                        onRootClose={[Function]}
+                      >
+                        <ul
+                          aria-labelledby="my-id"
+                          className="dropdown-menu"
+                          role="menu"
+                        >
+                          <MenuItem
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey="one-vm"
+                            header={false}
+                            key=".$one-vm"
+                            onKeyDown={[Function]}
+                            onSelect={[Function]}
+                          >
+                            <li
+                              className=""
+                              role="presentation"
+                            >
+                              <SafeAnchor
+                                componentClass="a"
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                role="menuitem"
+                                tabIndex="-1"
+                              >
+                                <a
+                                  href="#"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  one-vm
+                                </a>
+                              </SafeAnchor>
+                            </li>
+                          </MenuItem>
+                          <MenuItem
+                            bsClass="dropdown"
+                            disabled={false}
+                            divider={false}
+                            eventKey="vm-name"
+                            header={false}
+                            key=".$vm-name"
+                            onKeyDown={[Function]}
+                            onSelect={[Function]}
+                          >
+                            <li
+                              className=""
+                              role="presentation"
+                            >
+                              <SafeAnchor
+                                componentClass="a"
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                role="menuitem"
+                                tabIndex="-1"
+                              >
+                                <a
+                                  href="#"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="menuitem"
+                                  tabIndex="-1"
+                                >
+                                  vm-name
+                                </a>
+                              </SafeAnchor>
+                            </li>
+                          </MenuItem>
+                        </ul>
+                      </RootCloseWrapper>
+                    </DropdownMenu>
+                  </div>
+                </ButtonGroup>
+              </Dropdown>
+            </Uncontrolled(Dropdown)>
+          </DropdownButton>
+        </DropdownButton>
+      </div>
+    </ButtonGroup>
+  </Dropdown>
+</VCenterVmsWithPrefill>
+`;
+
+exports[`<VCenterVmsWithPrefill /> renders correctly 1`] = `
+<Dropdown
+  choices={
+    Array [
+      "one-vm",
+      "vm-name",
+    ]
+  }
+  disabled={true}
+  id="my-id"
+  onChange={[MockFunction]}
+  value="vm-name"
+  withTooltips={false}
+/>
+`;

--- a/src/components/Wizard/CreateVmWizard/providers/tests/vmwareActions.test.js
+++ b/src/components/Wizard/CreateVmWizard/providers/tests/vmwareActions.test.js
@@ -1,12 +1,13 @@
-import { onVmwareCheckConnection, onVCenterInstanceSelected } from '../vmwareActions';
+import { onVmwareCheckConnection, onVCenterInstanceSelected, onVCenterVmSelectedConnected } from '../vmwareActions';
 import { basicSettingsImportVmwareNewConnection } from '../../../../../tests/forms_mocks/basicSettings.mock';
-import { k8sCreate } from '../../../../../tests/k8s';
+import { k8sCreate, k8sGet } from '../../../../../tests/k8s';
 import {
   PROVIDER_STATUS_CONNECTING,
   PROVIDER_STATUS_CONNECTION_FAILED,
   PROVIDER_VMWARE_CONNECTION,
   PROVIDER_VMWARE_USER_PWD_AND_CHECK_KEY,
 } from '../../constants';
+import { V2VVMwareModel } from '../../../../../models';
 
 describe('vmware UI action', () => {
   it('onVmwareCheckConnection() works', async () => {
@@ -41,5 +42,26 @@ describe('vmware UI action', () => {
       expect.stringMatching('')
     );
     expect(onFormChange.mock.calls[0][1]).toBe(PROVIDER_VMWARE_USER_PWD_AND_CHECK_KEY);
+  });
+  it('onVCenterVmSelectedConnected() works', async () => {
+    const onFormChange = jest.fn();
+    const k8sPatch = jest.fn();
+
+    await onVCenterVmSelectedConnected(
+      k8sCreate,
+      k8sGet,
+      k8sPatch,
+      { value: 'test-vm2-name' },
+      undefined, // key,
+      undefined, // formValid
+      basicSettingsImportVmwareNewConnection,
+      onFormChange
+    );
+    expect(k8sPatch.mock.calls).toHaveLength(1);
+    expect(k8sPatch.mock.calls[0][0].kind).toBe(V2VVMwareModel.kind);
+    expect(k8sPatch.mock.calls[0][2][0].path).toBe('/spec/vms/1/detailRequest');
+    expect(k8sPatch.mock.calls[0][2][0].op).toBe('replace');
+
+    expect(onFormChange.mock.calls).toHaveLength(0); // VM Name is set by the user, so don't touch
   });
 });

--- a/src/components/Wizard/CreateVmWizard/providers/vmwareActions.js
+++ b/src/components/Wizard/CreateVmWizard/providers/vmwareActions.js
@@ -140,7 +140,7 @@ export const onVCenterVmSelectedConnected = async (
   const namespace = settingsValue(prevBasicSettings, NAMESPACE_KEY);
 
   // see onVCenterInstanceSelected()
-  const V2VVmwareName = get(settingsValue(settingsValue, PROVIDER_VMWARE_USER_PWD_AND_CHECK_KEY), [
+  const V2VVmwareName = get(settingsValue(prevBasicSettings, PROVIDER_VMWARE_USER_PWD_AND_CHECK_KEY), [
     PROVIDER_VMWARE_CONNECTION,
     'V2VVmwareName',
   ]);

--- a/src/tests/k8s.js
+++ b/src/tests/k8s.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import * as _ from 'lodash';
 
-import { ProcessedTemplatesModel } from '../models';
+import { ProcessedTemplatesModel, V2VVMwareModel } from '../models';
 import { TEMPLATE_PARAM_VM_NAME } from '../constants';
 
 const processTemplate = template =>
@@ -13,7 +13,26 @@ const processTemplate = template =>
   });
 
 export const k8sGet = (model, name, ns, opts) => {
-  console.warn('TODO: tests/k8s.js k8sGet() not implemented: ', model, name, ns, opts);
+  if (model.kind === V2VVMwareModel.kind) {
+    const v2vvmware = {
+      spec: {
+        vms: [
+          {
+            name: 'test-vm1-name',
+          },
+          {
+            name: 'test-vm2-name',
+          },
+          {
+            name: 'test-vm3-name',
+          },
+        ],
+      },
+    };
+    return v2vvmware;
+  }
+
+  throw new Error('Mock k8sGet() function is not implemented for that flow.');
 };
 
 export const k8sCreate = (model, resource) => {


### PR DESCRIPTION
If the user did not change the VM name or description fields within the CreateVmWizard, they are automatically pre-filled with the values from the imported VMWare VM.

To highlight:
- `FormFactory.getFormElement()` passes `onFormChange()` to a custom component. This slightly breaks encapsulation given by strictly context-bound `onChange()` but enables to build more complex flows in a custom component and so keeping business logic better co-located instead of spreading it to different layers (i.e. poluting BasicsettingsTab and CreateVmWizard components with inner-flow details).
- the `onFormChange()` handles `BATCH_CHANGES_KEY` so an array of `{ target, value }` pairs can be passed within a single call. We can consider this as a sort of "transaction". With existing design, it is not possible to call `onFormChange()` multiple-times in a single event handling as it is bound to `basicSettings` at the render time, so multiple write attempts collide. Different possible solutions:
  - use sort of `setTimeout(onFormChange, 0)` - recently working but ugly and not-reliable in the long-term
  - refactor flows around `CreateVmWizard.setState()`, resp. `onChange()` to manipulate with most recent verision of `stepData`. Passing of just the diff instead of recent whole single-stepData would be needed.

