### PR TITLE
v2v: Delete V2VVMWare object on CreateVmWizard close

### DIFF
--- a/src/components/Wizard/CreateVmWizard/BasicSettingsTab.js
+++ b/src/components/Wizard/CreateVmWizard/BasicSettingsTab.js
@@ -391,7 +391,7 @@ export const onCloseBasic = async (basicSettings, callerContext) => {
     const resource = {
       metadata: {
         name: v2vvmwareName,
-        // TODO: potential issue if user changed the namespace after creation
+        // TODO: potential issue if the user changed the namespace after creation of the v2vvmware object
         // to fix: either store the namespace along the v2vvmwareName or empty v2vvmwareName on namespace change
         namespace: settingsValue(basicSettings, NAMESPACE_KEY),
       },

--- a/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { findIndex } from 'lodash';
 import { Wizard } from 'patternfly-react';
 
-import { BasicSettingsTab } from './BasicSettingsTab';
+import { BasicSettingsTab, onCloseBasic } from './BasicSettingsTab';
 import { StorageTab } from './StorageTab';
 import { ResultTab } from './ResultTab';
 import { ResultTabRow } from './ResultTabRow';
@@ -309,10 +309,26 @@ export class CreateVmWizard extends React.Component {
     }
   };
 
+  onHideWrapper = (...eventArgs) => {
+    this.wizardStepsNewVM.forEach(step => {
+      if (step.onCloseWizard) {
+        const callerContext = {
+          k8sKill: this.props.k8sKill,
+        };
+        step.onCloseWizard(this.state.stepData[step.key].value, callerContext);
+      }
+    });
+
+    if (this.props.onHide) {
+      this.props.onHide(...eventArgs);
+    }
+  };
+
   wizardStepsNewVM = [
     {
       title: STEP_BASIC_SETTINGS,
       key: BASIC_SETTINGS_TAB_KEY,
+      onCloseWizard: onCloseBasic,
       render: () => {
         const loadingData = {
           namespaces: this.props.namespaces,
@@ -331,6 +347,7 @@ export class CreateVmWizard extends React.Component {
             k8sCreate={this.props.k8sCreate}
             k8sGet={this.props.k8sGet}
             k8sPatch={this.props.k8sPatch}
+            k8sKill={this.props.k8sKill}
           />
         );
       },
@@ -400,7 +417,7 @@ export class CreateVmWizard extends React.Component {
     return (
       <Wizard.Pattern
         show
-        onHide={this.props.onHide}
+        onHide={this.onHideWrapper}
         steps={this.wizardStepsNewVM}
         activeStepIndex={this.state.activeStepIndex}
         onStepChanged={index => this.onStepChanged(index)}
@@ -432,6 +449,7 @@ CreateVmWizard.propTypes = {
   k8sCreate: PropTypes.func.isRequired,
   k8sGet: PropTypes.func.isRequired,
   k8sPatch: PropTypes.func.isRequired,
+  k8sKill: PropTypes.func.isRequired,
   onHide: PropTypes.func.isRequired,
   templates: PropTypes.array,
   namespaces: PropTypes.array,

--- a/src/components/Wizard/CreateVmWizard/providers/VCenterVms.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VCenterVms.js
@@ -8,8 +8,8 @@ import { V2VVMwareModel } from '../../../../models';
 import { Dropdown } from '../../../Form';
 
 import { PROVIDER_SELECT_VM } from '../strings';
-import { NAMESPACE_KEY, PROVIDER_VMWARE_CONNECTION, PROVIDER_VMWARE_USER_PWD_AND_CHECK_KEY } from '../constants';
-import { settingsValue } from '../../../../k8s/selectors';
+import { NAMESPACE_KEY } from '../constants';
+import { settingsValue, getV2VVmwareName } from '../../../../k8s/selectors';
 
 import VCenterVmsWithPrefill from './VCenterVmsWithPrefill';
 
@@ -17,12 +17,7 @@ const VCenterVms = ({ onChange, onFormChange, id, value, extraProps, ...extra })
   // the "value" is name of selected VMWare VM
   const { WithResources, basicSettings } = extraProps;
 
-  const v2vvmwareName = get(basicSettings, [
-    PROVIDER_VMWARE_USER_PWD_AND_CHECK_KEY,
-    'value',
-    PROVIDER_VMWARE_CONNECTION,
-    'V2VVmwareName',
-  ]);
+  const v2vvmwareName = getV2VVmwareName(basicSettings);
 
   if (!v2vvmwareName) {
     return <Dropdown id={id} value={PROVIDER_SELECT_VM} disabled />;

--- a/src/components/Wizard/CreateVmWizard/providers/vmwareActions.js
+++ b/src/components/Wizard/CreateVmWizard/providers/vmwareActions.js
@@ -14,7 +14,7 @@ import {
   PROVIDER_VMWARE_CONNECTION,
 } from '../constants';
 import { CONNECT_TO_NEW_INSTANCE } from '../strings';
-import { settingsValue } from '../../../../k8s/selectors';
+import { settingsValue, getV2VVmwareName } from '../../../../k8s/selectors';
 import { getName } from '../../../../utils/selectors';
 
 export const onVmwareCheckConnection = async (basicSettings, onChange, k8sCreate) => {
@@ -140,10 +140,7 @@ export const onVCenterVmSelectedConnected = async (
   const namespace = settingsValue(prevBasicSettings, NAMESPACE_KEY);
 
   // see onVCenterInstanceSelected()
-  const V2VVmwareName = get(settingsValue(prevBasicSettings, PROVIDER_VMWARE_USER_PWD_AND_CHECK_KEY), [
-    PROVIDER_VMWARE_CONNECTION,
-    'V2VVmwareName',
-  ]);
+  const V2VVmwareName = getV2VVmwareName(prevBasicSettings);
   const vmName = (value || '').trim();
 
   try {

--- a/src/components/Wizard/CreateVmWizard/tests/BasicSettingsTab.test.js
+++ b/src/components/Wizard/CreateVmWizard/tests/BasicSettingsTab.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { MenuItem } from 'patternfly-react';
 
-import { BasicSettingsTab, getFormFields } from '../BasicSettingsTab';
+import { BasicSettingsTab, getFormFields, onCloseBasic } from '../BasicSettingsTab';
 import { namespaces } from '../fixtures/CreateVmWizard.fixture';
 import { baseTemplates } from '../../../../k8s/objects/template';
 import { validBasicSettings } from '../fixtures/BasicSettingsTab.fixture';
@@ -14,6 +14,8 @@ import { Dropdown } from '../../../Form';
 import { NO_TEMPLATE } from '../strings';
 import { selectVm } from '../../../../k8s/selectors';
 import { callerContext } from '../../../../tests/k8s';
+
+import { basicSettingsImportVmwareNewConnection } from '../../../../tests/forms_mocks/basicSettings.mock';
 
 import {
   userTemplates,
@@ -525,6 +527,13 @@ describe('<BasicSettingsTab />', () => {
       flavor: false,
       workload: false,
     });
+  });
+
+  it('removes temporary v2vvmware', async () => {
+    const k8sKill = jest.fn();
+    await onCloseBasic(basicSettingsImportVmwareNewConnection, { k8sKill });
+    expect(k8sKill.mock.calls).toHaveLength(1);
+    expect(k8sKill.mock.calls[0][1].metadata.name).toEqual('v2vvmware-object-name');
   });
 });
 

--- a/src/components/Wizard/CreateVmWizard/tests/__snapshots__/CreateVmWizard.test.js.snap
+++ b/src/components/Wizard/CreateVmWizard/tests/__snapshots__/CreateVmWizard.test.js.snap
@@ -27,6 +27,7 @@ exports[`<CreateVmWizard /> renders correctly 1`] = `
     Array [
       Object {
         "key": "basicSettings",
+        "onCloseWizard": [Function],
         "render": [Function],
         "title": "Basic Settings",
       },

--- a/src/k8s/selectors.js
+++ b/src/k8s/selectors.js
@@ -20,6 +20,8 @@ import {
   FLAVOR_KEY,
   WORKLOAD_PROFILE_KEY,
   PROVIDER_KEY,
+  PROVIDER_VMWARE_USER_PWD_AND_CHECK_KEY,
+  PROVIDER_VMWARE_CONNECTION,
 } from '../components/Wizard/CreateVmWizard/constants';
 
 export const settingsValue = (basicSettings, key, defaultValue) => get(basicSettings, [key, 'value'], defaultValue);
@@ -124,3 +126,9 @@ export const getTemplateAnnotations = (template, name) => get(template.metadata.
 export const selectVm = objects => objects.find(obj => obj.kind === VirtualMachineModel.kind);
 
 export const getModelApi = model => `${model.apiGroup}/${model.apiVersion}`;
+
+export const getV2VVmwareName = basicSettings =>
+  get(settingsValue(basicSettings, PROVIDER_VMWARE_USER_PWD_AND_CHECK_KEY), [
+    PROVIDER_VMWARE_CONNECTION,
+    'V2VVmwareName',
+  ]);

--- a/src/tests/k8s.js
+++ b/src/tests/k8s.js
@@ -35,6 +35,9 @@ export const k8sGet = (model, name, ns, opts) => {
   throw new Error('Mock k8sGet() function is not implemented for that flow.');
 };
 
+// mock implementation
+export const k8sKill = (model, resource) => resource;
+
 export const k8sCreate = (model, resource) => {
   if (model === ProcessedTemplatesModel) {
     return processTemplate(resource);
@@ -112,5 +115,6 @@ export const callerContext = {
   k8sCreate,
   k8sGet,
   k8sPatch,
+  k8sKill,
   WithResources,
 };


### PR DESCRIPTION
It is just a friendly help to keep things clean.

The garbage collector would remove these left-overs anyway but after a delay.
Thanks to this PR, the V2VVMWare are removed sooner.