### PR TITLE
Details: remove search&hash elipsization

### DIFF
--- a/src/components/Details/Url/Url.js
+++ b/src/components/Details/Url/Url.js
@@ -29,15 +29,8 @@ const resolvePathname = ({ pathname }, maxPathnameParts) => {
   return `/${elipsizeLeft(`/${resolvedPathname}`)}`;
 };
 
-const resolveUrl = ({ urlObj, maxHostnameParts, maxPathnameParts }) => {
-  const { search, hash } = urlObj;
-
-  const resolvedOrigin = resolveOrigin(urlObj, maxHostnameParts);
-  const resolvedPathname = resolvePathname(urlObj, maxPathnameParts);
-  const resolvedSearchHash = search.length > 0 || hash.length > 0 ? ELIPSIS : '';
-
-  return `${resolvedOrigin}${resolvedPathname}${resolvedSearchHash}`;
-};
+const resolveUrl = ({ urlObj, maxHostnameParts, maxPathnameParts }) =>
+  `${resolveOrigin(urlObj, maxHostnameParts)}${resolvePathname(urlObj, maxPathnameParts)}`;
 
 export const Url = ({ url, short, maxHostnameParts, maxPathnameParts }) => {
   const urlObj = short ? parseUrl(url) : undefined;

--- a/src/components/Details/Url/tests/__snapshots__/Url.test.js.snap
+++ b/src/components/Details/Url/tests/__snapshots__/Url.test.js.snap
@@ -26,7 +26,7 @@ exports[`<Url /> renders correctly 2`] = `
     href="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
     title="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
   >
-    …mountain.all-images.cz/…/dromaeosauridae.iso…
+    …mountain.all-images.cz/…/dromaeosauridae.iso
   </a>
 </Url>
 `;

--- a/src/components/Details/VmTemplateDetails/tests/__snapshots__/VmTemplateDetails.test.js.snap
+++ b/src/components/Details/VmTemplateDetails/tests/__snapshots__/VmTemplateDetails.test.js.snap
@@ -362,7 +362,7 @@ exports[`<VmTemplateDetails /> renders url correctly 1`] = `
                   href="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
                   title="http://rock.mountain.all-images.cz/mirrors/there-was-a-toad/on/a/blue/happy/road/0.12.13/isos/x86_64/dromaeosauridae.iso?a=1&b=caaaaaaaaaaddddddddaaaaaaa#here"
                 >
-                  …mountain.all-images.cz/…/dromaeosauridae.iso…
+                  …mountain.all-images.cz/…/dromaeosauridae.iso
                 </a>
               </div>
             </dd>


### PR DESCRIPTION
this PR removes the parameters and hash part 

moving conversation from #229 to here:

@andybraren

> Ah you’re right, I agree that hinting at additional subdomains is important and the “...” should be kept in that case.
>
> Are protocols other than http/https (ftp/sftp/smb) supported? If yes then the protocol is probably important enough to show at all times, despite the increased length. If no then I would still lean toward being able to hide http/https entirely without a “...”, but I defer to your judgment in this context.
>
> So my proposal:
>
> https://...sub.domain.com/filename.iso (additional subdomains stripped, but protocol is kept because we decide it’s important)
>
> sub.domain.com/.../filename.iso (we decide the protocol is not important)
>
> ...sub.domain.com/.../filename.iso (we decide the protocol is not important, so the starting “...” only represents additional subdomains)

It seems that only http/https are supported for now. But IMO opinion showing that distinction is important. 

![c](https://user-images.githubusercontent.com/3648838/53640751-44fae900-3c2d-11e9-9a32-467827737603.png)


But when there are many subdomains I think the protocol could be hidden. It can be seen in the full url on hover. I think the ellipsis indicates the presence of the protocol enough which I think could be sufficient.

![a](https://user-images.githubusercontent.com/3648838/53640456-88a12300-3c2c-11e9-881e-836888074a10.png)


> Another consideration - are there situations where port numbers would be included in the URL? If so, that number should probably be shown too

There might be. The port number is already included in the shortened url
 