### PR TITLE
v2v: prefill operating system

### DIFF
--- a/src/components/Wizard/CreateVmWizard/BasicSettingsTab.js
+++ b/src/components/Wizard/CreateVmWizard/BasicSettingsTab.js
@@ -141,7 +141,7 @@ export const getFormFields = (
       choices: userTemplateNames,
     };
 
-    providersSection = importProviders(basicSettings, WithResources, k8sCreate, k8sGet, k8sPatch);
+    providersSection = importProviders(basicSettings, operatingSystems, WithResources, k8sCreate, k8sGet, k8sPatch);
     imageSources.push(PROVISION_SOURCE_IMPORT);
   }
 

--- a/src/components/Wizard/CreateVmWizard/BasicSettingsTab.js
+++ b/src/components/Wizard/CreateVmWizard/BasicSettingsTab.js
@@ -293,11 +293,8 @@ const publish = ({ basicSettings, templates, onChange, dataVolumes }, value, tar
     };
     value.value.forEach(pair => {
       // set field validation
-      newBasicSettings[pair.target].validation = pair.validation || getFieldValidation(
-        formFields[pair.target],
-        pair.value,
-        newBasicSettings
-      );
+      newBasicSettings[pair.target].validation =
+        pair.validation || getFieldValidation(formFields[pair.target], pair.value, newBasicSettings);
     });
     formValid = validateForm(formFields, newBasicSettings);
   } else {

--- a/src/components/Wizard/CreateVmWizard/BasicSettingsTab.js
+++ b/src/components/Wizard/CreateVmWizard/BasicSettingsTab.js
@@ -293,7 +293,7 @@ const publish = ({ basicSettings, templates, onChange, dataVolumes }, value, tar
     };
     value.value.forEach(pair => {
       // set field validation
-      newBasicSettings[pair.target].validation = getFieldValidation(
+      newBasicSettings[pair.target].validation = pair.validation || getFieldValidation(
         formFields[pair.target],
         pair.value,
         newBasicSettings

--- a/src/components/Wizard/CreateVmWizard/providers/VCenterVms.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VCenterVms.js
@@ -15,7 +15,7 @@ import VCenterVmsWithPrefill from './VCenterVmsWithPrefill';
 
 const VCenterVms = ({ onChange, onFormChange, id, value, extraProps, ...extra }) => {
   // the "value" is name of selected VMWare VM
-  const { WithResources, basicSettings } = extraProps;
+  const { WithResources, basicSettings, operatingSystems, k8sGet } = extraProps;
 
   const v2vvmwareName = getV2VVmwareName(basicSettings);
 
@@ -53,6 +53,8 @@ const VCenterVms = ({ onChange, onFormChange, id, value, extraProps, ...extra })
         onChange={onChange}
         onFormChange={onFormChange}
         basicSettings={basicSettings}
+        operatingSystems={operatingSystems}
+        k8sGet={k8sGet}
       />
     </WithResources>
   );

--- a/src/components/Wizard/CreateVmWizard/providers/VCenterVmsWithPrefill.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VCenterVmsWithPrefill.js
@@ -13,8 +13,8 @@ import {
   PROVIDER_VMWARE_VM_KEY,
 } from '../constants';
 import { getVmwareToKubevirtOS } from './vmwareActions';
-import {getValidationObject} from "../../../../utils";
-import {VALIDATION_INFO_TYPE} from "../../../../constants";
+import { getValidationObject } from '../../../../utils';
+import { VALIDATION_INFO_TYPE } from '../../../../constants';
 import { getVmwareOsString } from '../strings';
 
 class VCenterVmsWithPrefill extends React.Component {
@@ -76,7 +76,7 @@ class VCenterVmsWithPrefill extends React.Component {
       return {
         value: formValue,
         target: OPERATING_SYSTEM_KEY,
-        validation: getValidationObject(getVmwareOsString(guestFullName), VALIDATION_INFO_TYPE)
+        validation: getValidationObject(getVmwareOsString(guestFullName), VALIDATION_INFO_TYPE),
       };
     }
 

--- a/src/components/Wizard/CreateVmWizard/providers/index.js
+++ b/src/components/Wizard/CreateVmWizard/providers/index.js
@@ -20,7 +20,7 @@ const getProviderHelp = basicSettings => {
   }
 };
 
-export const importProviders = (basicSettings, WithResources, k8sCreate, k8sGet, k8sPatch) => ({
+export const importProviders = (basicSettings, operatingSystems, WithResources, k8sCreate, k8sGet, k8sPatch) => ({
   [PROVIDER_KEY]: {
     id: 'provider-dropdown',
     title: 'Provider',
@@ -32,7 +32,7 @@ export const importProviders = (basicSettings, WithResources, k8sCreate, k8sGet,
     isVisible: basicVmSettings => isImageSourceType(basicVmSettings, PROVISION_SOURCE_IMPORT),
     help: getProviderHelp(basicSettings),
   },
-  ...getVMWareSection(basicSettings, WithResources, k8sCreate, k8sGet, k8sPatch),
+  ...getVMWareSection(basicSettings, operatingSystems, WithResources, k8sCreate, k8sGet, k8sPatch),
 });
 
 const onProviderChanged = (k8sCreate, k8sGet, valueValidationPair, key, formValid, prevBasicSettings) => {

--- a/src/components/Wizard/CreateVmWizard/providers/tests/VCenterVms.test.js
+++ b/src/components/Wizard/CreateVmWizard/providers/tests/VCenterVms.test.js
@@ -1,13 +1,17 @@
 import React from 'react';
 import { render } from 'enzyme/build';
 
-import { WithResources } from '../../../../../tests/k8s';
+import { k8sGet, WithResources } from '../../../../../tests/k8s';
 import VCenterVms from '../VCenterVms';
 import { basicSettingsImportVmwareNewConnection } from '../../../../../tests/forms_mocks/basicSettings.mock';
+import { getOperatingSystems } from '../../../../..';
+import { baseTemplates } from '../../../../../k8s/objects/template';
 
 const extraProps = {
   WithResources,
   basicSettings: basicSettingsImportVmwareNewConnection,
+  k8sGet,
+  operatingSystems: getOperatingSystems(basicSettingsImportVmwareNewConnection, baseTemplates),
 };
 
 describe('<VCenterVms /> for list of vCenter secrets', () => {

--- a/src/components/Wizard/CreateVmWizard/providers/tests/VCenterVmsWithPrefill.test.js
+++ b/src/components/Wizard/CreateVmWizard/providers/tests/VCenterVmsWithPrefill.test.js
@@ -2,15 +2,21 @@ import React from 'react';
 import { mount, shallow } from 'enzyme/build';
 
 import { basicSettingsImportVmwareNewConnection } from '../../../../../tests/forms_mocks/basicSettings.mock';
+import { k8sGet } from '../../../../../tests/k8s';
+import { delay } from '../../../../../utils/utils';
 
 import VCenterVmsWithPrefill from '../VCenterVmsWithPrefill';
 import { BATCH_CHANGES_KEY, PROVIDER_VMWARE_VM_KEY, NAME_KEY, DESCRIPTION_KEY } from '../../constants';
+import { getOperatingSystems } from '../../../../../k8s/selectors';
+import { baseTemplates } from '../../../../../k8s/objects/template';
 
 const props = {
   id: 'my-id',
   value: 'vm-name',
   choices: ['one-vm', 'vm-name'],
   basicSettings: basicSettingsImportVmwareNewConnection,
+  k8sGet,
+  operatingSystems: getOperatingSystems(basicSettingsImportVmwareNewConnection, baseTemplates),
 };
 props.basicSettings[PROVIDER_VMWARE_VM_KEY] = {
   value: 'vm-name',
@@ -47,7 +53,7 @@ describe('<VCenterVmsWithPrefill />', () => {
     const wrapper = shallow(<VCenterVmsWithPrefill {...props} onChange={onChange} onFormChange={onFormChange} />);
     expect(wrapper).toMatchSnapshot();
   });
-  it('does prefill', () => {
+  it('does prefill', async () => {
     const onChange = jest.fn();
     const onFormChange = jest.fn();
     const wrapper = mount(<VCenterVmsWithPrefill {...props} onChange={onChange} onFormChange={onFormChange} />);
@@ -55,7 +61,8 @@ describe('<VCenterVmsWithPrefill />', () => {
     expect(onChange.mock.calls).toHaveLength(0);
     expect(onFormChange.mock.calls).toHaveLength(0);
 
-    wrapper.setProps({ v2vvmware }); // force componentDidUpdate
+    wrapper.setProps({ v2vvmware }); // force componentDidUpdate containing async processing
+    await delay(100);
     expect(onChange.mock.calls).toHaveLength(0);
     expect(onFormChange.mock.calls).toHaveLength(1);
     expect(onFormChange.mock.calls[0][1]).toBe(BATCH_CHANGES_KEY);
@@ -64,6 +71,7 @@ describe('<VCenterVmsWithPrefill />', () => {
     const newBasicSettings = props.basicSettings;
     newBasicSettings[NAME_KEY] = '';
     wrapper.setProps({ basicSettings: newBasicSettings });
+    await delay(100); // allow async prefill to finish
     expect(onFormChange.mock.calls).toHaveLength(2);
     expect(onFormChange.mock.calls[1][1]).toBe(BATCH_CHANGES_KEY);
     expect(onFormChange.mock.calls[1][0].value[0]).toEqual({ value: 'vm-name', target: NAME_KEY }); // description is skipped as it is equal with former run

--- a/src/components/Wizard/CreateVmWizard/providers/tests/VCenterVmsWithPrefill.test.js
+++ b/src/components/Wizard/CreateVmWizard/providers/tests/VCenterVmsWithPrefill.test.js
@@ -3,7 +3,7 @@ import { mount, shallow } from 'enzyme/build';
 
 import { basicSettingsImportVmwareNewConnection } from '../../../../../tests/forms_mocks/basicSettings.mock';
 import { k8sGet } from '../../../../../tests/k8s';
-import { delay } from '../../../../../utils/utils';
+import { flushPromises } from '../../../../../tests/enzyme';
 
 import VCenterVmsWithPrefill from '../VCenterVmsWithPrefill';
 import {
@@ -71,7 +71,7 @@ describe('<VCenterVmsWithPrefill />', () => {
     expect(onFormChange.mock.calls).toHaveLength(0);
 
     wrapper.setProps({ v2vvmware }); // force componentDidUpdate containing async processing
-    await delay(100);
+    await flushPromises();
     expect(onChange.mock.calls).toHaveLength(0);
     expect(onFormChange.mock.calls).toHaveLength(2);
     expect(onFormChange.mock.calls[0][1]).toBe(BATCH_CHANGES_KEY);
@@ -86,7 +86,7 @@ describe('<VCenterVmsWithPrefill />', () => {
     const newBasicSettings = Object.assign({}, props.basicSettings);
     newBasicSettings[NAME_KEY] = '';
     wrapper.setProps({ basicSettings: newBasicSettings });
-    await delay(100); // allow async prefill to finish
+    await flushPromises();
     expect(onFormChange.mock.calls).toHaveLength(3);
     expect(onFormChange.mock.calls[2][1]).toBe(BATCH_CHANGES_KEY);
     expect(onFormChange.mock.calls[2][0].value[0]).toEqual({ value: 'vm-name', target: NAME_KEY }); // description is skipped as it is equal with former run

--- a/src/components/Wizard/CreateVmWizard/providers/tests/__snapshots__/VCenterVmsWithPrefill.test.js.snap
+++ b/src/components/Wizard/CreateVmWizard/providers/tests/__snapshots__/VCenterVmsWithPrefill.test.js.snap
@@ -61,8 +61,49 @@ exports[`<VCenterVmsWithPrefill /> does prefill 1`] = `
   }
   disabled={true}
   id="my-id"
+  k8sGet={[Function]}
   onChange={[MockFunction]}
   onFormChange={[MockFunction]}
+  operatingSystems={
+    Array [
+      Object {
+        "id": "fedora29",
+        "name": "Fedora 29",
+      },
+      Object {
+        "id": "fedora28",
+        "name": "Fedora 28",
+      },
+      Object {
+        "id": "fedora27",
+        "name": "Fedora 27",
+      },
+      Object {
+        "id": "fedora26",
+        "name": "Fedora 26",
+      },
+      Object {
+        "id": "fedora25",
+        "name": "Fedora 25",
+      },
+      Object {
+        "id": "fedora24",
+        "name": "Fedora 24",
+      },
+      Object {
+        "id": "fedora23",
+        "name": "Fedora 23",
+      },
+      Object {
+        "id": "rhel7.0",
+        "name": "Red Hat Enterprise Linux 7.0",
+      },
+      Object {
+        "id": "ubuntu18.04",
+        "name": "Ubuntu 18.04 LTS",
+      },
+    ]
+  }
   value="vm-name"
 >
   <Dropdown

--- a/src/components/Wizard/CreateVmWizard/providers/vmware.js
+++ b/src/components/Wizard/CreateVmWizard/providers/vmware.js
@@ -66,7 +66,7 @@ const getVMWareNewConnectionSection = (basicSettings, WithResources, k8sCreate) 
   },
 });
 
-export const getVMWareSection = (basicSettings, WithResources, k8sCreate, k8sGet, k8sPatch) => ({
+export const getVMWareSection = (basicSettings, operatingSystems, WithResources, k8sCreate, k8sGet, k8sPatch) => ({
   [PROVIDER_VMWARE_VCENTER_KEY]: {
     id: 'vcenter-instance-dropdown',
     title: 'vCenter Instance',
@@ -90,7 +90,9 @@ export const getVMWareSection = (basicSettings, WithResources, k8sCreate, k8sGet
     CustomComponent: VCenterVms,
     extraProps: {
       WithResources,
+      k8sGet,
       basicSettings,
+      operatingSystems,
     },
     onChange: (...props) => onVCenterVmSelectedConnected(k8sCreate, k8sGet, k8sPatch, ...props),
     required: true,

--- a/src/components/Wizard/CreateVmWizard/providers/vmwareActions.js
+++ b/src/components/Wizard/CreateVmWizard/providers/vmwareActions.js
@@ -199,11 +199,20 @@ export const onVCenterVmSelectedConnected = async (
  * @param guestId - VMWare's operating system identifier
  */
 export const getVmwareToKubevirtOS = async (operatingSystems, guestId, k8sGet) => {
-  const vmwareToKubevirtOsConfigMap = await k8sGet(
-    ConfigMapModel,
-    VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAME,
-    VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAMESPACE
-  );
-  const kubevirtId = get(vmwareToKubevirtOsConfigMap, ['data', guestId]);
-  return operatingSystems.find(os => os.id === kubevirtId);
+  try {
+    const vmwareToKubevirtOsConfigMap = await k8sGet(
+      ConfigMapModel,
+      VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAME,
+      VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAMESPACE
+    );
+    const kubevirtId = get(vmwareToKubevirtOsConfigMap, ['data', guestId]);
+    return operatingSystems.find(os => os.id === kubevirtId);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `Can not find ${VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAME} ConfigMap in the ${VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAMESPACE} namespace for automatic pairing of VMWare operating system identifiers to kubevirt. Error: `,
+      error
+    );
+    return undefined; // presence of the mapping configmap is optional only
+  }
 };

--- a/src/components/Wizard/CreateVmWizard/providers/vmwareActions.js
+++ b/src/components/Wizard/CreateVmWizard/providers/vmwareActions.js
@@ -191,7 +191,7 @@ export const onVCenterVmSelectedConnected = async (
 /**
  * Provides mapping from VMWare GuesId to common-templates operating system.
  *
- * https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
+ * https://code.vmware.com/docs/4206/vsphere-web-services-api-reference#/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html
  *
  * The VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAME object is usually created by the web-ui-operator and can be missing.
  *

--- a/src/components/Wizard/CreateVmWizard/strings.js
+++ b/src/components/Wizard/CreateVmWizard/strings.js
@@ -30,6 +30,8 @@ export const HELP_PROVIDER_VMWARE =
 export const CONNECT_TO_NEW_INSTANCE = 'Connect to New Instance';
 export const PROVIDER_SELECT_VM = '--- Select VM ---';
 
+export const getVmwareOsString = osName => `Select matching for: ${osName}`;
+
 // NetworksTab
 export const SELECT_NETWORK = '--- Select Network Definition ---';
 export const REMOVE_NIC_BUTTON = 'Remove NIC';

--- a/src/components/Wizard/CreateVmWizard/tests/__snapshots__/BasicSettingsTab.test.js.snap
+++ b/src/components/Wizard/CreateVmWizard/tests/__snapshots__/BasicSettingsTab.test.js.snap
@@ -275,6 +275,61 @@ exports[`<BasicSettingsTab /> for Create VM Template renders correctly 1`] = `
         "extraProps": Object {
           "WithResources": [Function],
           "basicSettings": Object {},
+          "k8sGet": [Function],
+          "operatingSystems": Array [
+            Object {
+              "id": "fedora29",
+              "name": "Fedora 29",
+            },
+            Object {
+              "id": "fedora28",
+              "name": "Fedora 28",
+            },
+            Object {
+              "id": "fedora27",
+              "name": "Fedora 27",
+            },
+            Object {
+              "id": "fedora26",
+              "name": "Fedora 26",
+            },
+            Object {
+              "id": "fedora25",
+              "name": "Fedora 25",
+            },
+            Object {
+              "id": "fedora24",
+              "name": "Fedora 24",
+            },
+            Object {
+              "id": "fedora23",
+              "name": "Fedora 23",
+            },
+            Object {
+              "id": "rhel7.0",
+              "name": "Red Hat Enterprise Linux 7.0",
+            },
+            Object {
+              "id": "ubuntu18.04",
+              "name": "Ubuntu 18.04 LTS",
+            },
+            Object {
+              "id": "win2k12r2",
+              "name": "Microsoft Windows Server 2012 R2",
+            },
+            Object {
+              "id": "win2k8r2",
+              "name": "Microsoft Windows Server 2008 R2",
+            },
+            Object {
+              "id": "win2k8",
+              "name": "Microsoft Windows Server 2008",
+            },
+            Object {
+              "id": "win10",
+              "name": "Microsoft Windows 10",
+            },
+          ],
         },
         "help": "Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded.",
         "id": "vcenter-vm-dropdown",
@@ -581,6 +636,61 @@ exports[`<BasicSettingsTab /> renders correctly 1`] = `
         "extraProps": Object {
           "WithResources": [Function],
           "basicSettings": Object {},
+          "k8sGet": [Function],
+          "operatingSystems": Array [
+            Object {
+              "id": "fedora29",
+              "name": "Fedora 29",
+            },
+            Object {
+              "id": "fedora28",
+              "name": "Fedora 28",
+            },
+            Object {
+              "id": "fedora27",
+              "name": "Fedora 27",
+            },
+            Object {
+              "id": "fedora26",
+              "name": "Fedora 26",
+            },
+            Object {
+              "id": "fedora25",
+              "name": "Fedora 25",
+            },
+            Object {
+              "id": "fedora24",
+              "name": "Fedora 24",
+            },
+            Object {
+              "id": "fedora23",
+              "name": "Fedora 23",
+            },
+            Object {
+              "id": "rhel7.0",
+              "name": "Red Hat Enterprise Linux 7.0",
+            },
+            Object {
+              "id": "ubuntu18.04",
+              "name": "Ubuntu 18.04 LTS",
+            },
+            Object {
+              "id": "win2k12r2",
+              "name": "Microsoft Windows Server 2012 R2",
+            },
+            Object {
+              "id": "win2k8r2",
+              "name": "Microsoft Windows Server 2008 R2",
+            },
+            Object {
+              "id": "win2k8",
+              "name": "Microsoft Windows Server 2008",
+            },
+            Object {
+              "id": "win10",
+              "name": "Microsoft Windows 10",
+            },
+          ],
         },
         "help": "Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded.",
         "id": "vcenter-vm-dropdown",

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -75,3 +75,6 @@ export const STORAGE_IMPORT_PVC_NAME = 'storage.import.importPvcName';
 
 export const VCENTER_TYPE_LABEL = 'cnv.io/vcenter';
 export const VCENTER_TEMPORARY_LABEL = 'cnv.io/temporary';
+
+export const VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAMESPACE = 'kube-public'; // note: common-templates are in the "openshift" namespace
+export const VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAME = 'vmware-to-kubevirt-os'; // single OnfigMap per cluster, contains mapping of vmware guestId to common-templates OS ID

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -214,3 +214,15 @@ export const RoleBindingModel = {
   id: 'rolebinding',
   labelPlural: 'Role Bindings',
 };
+
+export const ConfigMapModel = {
+  apiVersion: 'v1',
+  label: 'Config Map',
+  path: 'configmaps',
+  plural: 'configmaps',
+  abbr: 'CM',
+  namespaced: true,
+  kind: 'ConfigMap',
+  id: 'configmap',
+  labelPlural: 'Config Maps',
+};

--- a/src/tests/k8s.js
+++ b/src/tests/k8s.js
@@ -46,6 +46,7 @@ export const k8sGet = (model, name, ns, opts) => {
         // purely dummy testing data
         rhel7_64Guest: 'rhel7.0',
         windows7Server64Guest: 'win2k8',
+        fedora28_guest: 'fedora28',
         windows9Server64Guest: '',
       },
       kind: 'ConfigMap',

--- a/src/tests/k8s.js
+++ b/src/tests/k8s.js
@@ -2,8 +2,12 @@ import React from 'react';
 
 import * as _ from 'lodash';
 
-import { ProcessedTemplatesModel, V2VVMwareModel } from '../models';
-import { TEMPLATE_PARAM_VM_NAME } from '../constants';
+import { ConfigMapModel, ProcessedTemplatesModel, V2VVMwareModel } from '../models';
+import {
+  TEMPLATE_PARAM_VM_NAME,
+  VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAME,
+  VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAMESPACE,
+} from '../constants';
 
 const processTemplate = template =>
   new Promise((resolve, reject) => {
@@ -32,7 +36,27 @@ export const k8sGet = (model, name, ns, opts) => {
     return v2vvmware;
   }
 
-  throw new Error('Mock k8sGet() function is not implemented for that flow.');
+  if (
+    model.kind === ConfigMapModel.kind &&
+    name === VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAME &&
+    ns === VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAMESPACE
+  ) {
+    const configMap = {
+      data: {
+        // purely dummy testing data
+        rhel7_64Guest: 'rhel7.0',
+        windows7Server64Guest: 'win2k8',
+        windows9Server64Guest: '',
+      },
+      kind: 'ConfigMap',
+      metadata: {},
+    };
+    return configMap;
+  }
+
+  throw new Error(
+    `Mock k8sGet() function is not implemented for that flow: model: ${model.kind}, name: ${name}, ns: ${ns}`
+  );
 };
 
 // mock implementation

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -65,5 +65,3 @@ export const getResource = (
 
   return res;
 };
-
-export const delay = ms => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -65,3 +65,5 @@ export const getResource = (
 
   return res;
 };
+
+export const delay = ms => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
In CreateVMWizard and v2v flow, the operating system is prefilled
based on input value from the VMWare VM.

Mapping of vmware to kubevirt OS value is done via ConfigMap (single per cluster):
 - name: vmware-to-kubevirt-os
 - namespace: kube-public

Presence of the ConfigMap is not required.

---

TODO:
- [x] handle missing mapping (vmware's OS name will be displayed)
- [x] unit tests
- [x] web-ui-operator: create `vmware-to-kubevirt-os` ConfigMap 
     - https://github.com/kubevirt/web-ui-operator/pull/28
     - https://github.com/kubevirt/kubevirt-ansible/pull/609
