### PR TITLE
v2v: prefill networks

### DIFF
--- a/src/components/Wizard/CreateVmWizard/BasicSettingsTab.js
+++ b/src/components/Wizard/CreateVmWizard/BasicSettingsTab.js
@@ -70,6 +70,7 @@ import {
   HOST_NAME_KEY,
   AUTHKEYS_KEY,
   BATCH_CHANGES_KEY,
+  INTERMEDIARY_NETWORKS_TAB_KEY,
 } from './constants';
 
 import { importProviders } from './providers';
@@ -292,9 +293,11 @@ const publish = ({ basicSettings, templates, onChange, dataVolumes }, value, tar
       ...difference,
     };
     value.value.forEach(pair => {
-      // set field validation
-      newBasicSettings[pair.target].validation =
-        pair.validation || getFieldValidation(formFields[pair.target], pair.value, newBasicSettings);
+      if (pair.target !== INTERMEDIARY_NETWORKS_TAB_KEY) {
+        // set field validation
+        newBasicSettings[pair.target].validation =
+          pair.validation || getFieldValidation(formFields[pair.target], pair.value, newBasicSettings);
+      }
     });
     formValid = validateForm(formFields, newBasicSettings);
   } else {

--- a/src/components/Wizard/CreateVmWizard/NetworksTab.js
+++ b/src/components/Wizard/CreateVmWizard/NetworksTab.js
@@ -207,82 +207,88 @@ export class NetworksTab extends React.Component {
     }));
   };
 
-  getColumns = () => [
-    {
-      header: {
-        label: HEADER_NAME,
-        props: {
-          style: {
-            width: '32%',
-          },
-        },
-      },
-      property: 'name',
-      renderConfig: () => ({
-        id: 'name-edit',
-        type: TEXT,
-      }),
-    },
-    {
-      header: {
-        label: HEADER_MAC,
-        props: {
-          style: {
-            width: '32%',
-          },
-        },
-      },
-      property: 'mac',
-      renderConfig: row =>
-        row.networkType === NETWORK_TYPE_POD
-          ? null
-          : {
-              id: 'mac-edit',
-              type: TEXT,
+  getColumns = () => {
+    const columns = [
+      {
+        header: {
+          label: HEADER_NAME,
+          props: {
+            style: {
+              width: '32%',
             },
-    },
-    {
-      header: {
-        label: HEADER_NETWORK,
-        props: {
-          style: {
-            width: '32%',
           },
         },
+        property: 'name',
+        renderConfig: () => ({
+          id: 'name-edit',
+          type: TEXT,
+        }),
       },
-      property: 'network',
-      renderConfig: () => ({
-        id: 'network-edit',
-        type: DROPDOWN,
-        choices: this.props.networkConfigs
-          .filter(networkConfig => networkConfig.metadata.namespace === this.props.namespace)
-          .map(networkConfig => networkConfig.metadata.name)
-          .concat(POD_NETWORK)
-          .filter(networkConfig => !this.state.rows.some(r => r.network === networkConfig)),
-        initialValue: SELECT_NETWORK,
-      }),
-    },
-    {
-      header: {
-        props: {
-          style: {
-            width: '4%',
+      {
+        header: {
+          label: HEADER_MAC,
+          props: {
+            style: {
+              width: '32%',
+            },
           },
         },
+        property: 'mac',
+        renderConfig: row =>
+          row.networkType === NETWORK_TYPE_POD
+            ? null
+            : {
+                id: 'mac-edit',
+                type: TEXT,
+              },
       },
-      type: ACTIONS_TYPE,
-      renderConfig: () => ({
-        id: 'actions',
-        actions: [
-          {
-            actionType: DELETE_ACTION,
-            text: REMOVE_NIC_BUTTON,
+      {
+        header: {
+          label: HEADER_NETWORK,
+          props: {
+            style: {
+              width: '32%',
+            },
           },
-        ],
-        visibleOnEdit: false,
-      }),
-    },
-  ];
+        },
+        property: 'network',
+        renderConfig: () => ({
+          id: 'network-edit',
+          type: DROPDOWN,
+          choices: this.props.networkConfigs
+            .filter(networkConfig => networkConfig.metadata.namespace === this.props.namespace)
+            .map(networkConfig => networkConfig.metadata.name)
+            .concat(POD_NETWORK)
+            .filter(networkConfig => !this.state.rows.some(r => r.network === networkConfig)),
+          initialValue: SELECT_NETWORK,
+        }),
+      },
+    ];
+
+    if (!this.props.isCreateRemoveDisabled) {
+      columns.push({
+        header: {
+          props: {
+            style: {
+              width: '4%',
+            },
+          },
+        },
+        type: ACTIONS_TYPE,
+        renderConfig: () => ({
+          id: 'actions',
+          actions: [
+            {
+              actionType: DELETE_ACTION,
+              text: REMOVE_NIC_BUTTON,
+            },
+          ],
+          visibleOnEdit: false,
+        }),
+      });
+    }
+    return columns;
+  };
 
   getActionButtons = () => [
     {
@@ -290,7 +296,7 @@ export class NetworksTab extends React.Component {
       onClick: this.createNic,
       id: 'create-network-btn',
       text: CREATE_NIC_BUTTON,
-      disabled: this.state.editing,
+      disabled: this.props.isCreateRemoveDisabled || this.state.editing,
     },
   ];
 
@@ -368,4 +374,5 @@ NetworksTab.propTypes = {
   sourceType: PropTypes.string.isRequired,
   networkConfigs: PropTypes.array.isRequired,
   namespace: PropTypes.string.isRequired,
+  isCreateRemoveDisabled: PropTypes.bool.isRequired,
 };

--- a/src/components/Wizard/CreateVmWizard/constants.js
+++ b/src/components/Wizard/CreateVmWizard/constants.js
@@ -19,6 +19,7 @@ export const HOST_NAME_KEY = 'hostname';
 export const AUTHKEYS_KEY = 'authKeys';
 export const CLOUD_INIT_CUSTOM_SCRIPT_KEY = 'cloudInitCustomScript';
 
+// Top-level stepData keys
 export const BASIC_SETTINGS_TAB_KEY = 'basicSettings';
 export const NETWORKS_TAB_KEY = 'network';
 export const STORAGE_TAB_KEY = 'storage';
@@ -53,3 +54,4 @@ export const PROVIDER_STATUS_CONNECTING = 'connecting';
 export const PROVIDER_STATUS_SUCCESS = 'success';
 export const PROVIDER_STATUS_CONNECTION_FAILED = 'connectionFailed';
 export const V2VVMWARE_DEPLOYMENT_NAME = 'v2v-vmware'; // probably no need to make the name generic
+export const INTERMEDIARY_NETWORKS_TAB_KEY = 'intermediaryNetworksData';

--- a/src/components/Wizard/CreateVmWizard/fixtures/NetworksTab.fixture.js
+++ b/src/components/Wizard/CreateVmWizard/fixtures/NetworksTab.fixture.js
@@ -10,5 +10,6 @@ export default {
     sourceType: PROVISION_SOURCE_PXE,
     networkConfigs,
     namespace: 'default',
+    isCreateRemoveDisabled: false,
   },
 };

--- a/src/components/Wizard/CreateVmWizard/tests/CreateVmWizard.test.js
+++ b/src/components/Wizard/CreateVmWizard/tests/CreateVmWizard.test.js
@@ -3,7 +3,7 @@ import { shallow, mount } from 'enzyme';
 import { findIndex } from 'lodash';
 import { WizardPattern } from 'patternfly-react';
 
-import { CreateVmWizard } from '../CreateVmWizard';
+import { CreateVmWizard, onVmwareVmChanged } from '../CreateVmWizard';
 import { Loading } from '../../../Loading';
 import { validBasicSettings } from '../fixtures/BasicSettingsTab.fixture';
 import { createVm, createVmTemplate } from '../../../../k8s/request';
@@ -26,6 +26,7 @@ import {
   PROVISION_SOURCE_TYPE_KEY,
   STORAGE_TYPE_CONTAINER,
   STORAGE_TYPE_DATAVOLUME,
+  INTERMEDIARY_NETWORKS_TAB_KEY,
 } from '../constants';
 
 import {
@@ -382,6 +383,57 @@ describe('<CreateVmWizard />', () => {
 
     component.instance().onStepDataChanged(BASIC_SETTINGS_TAB_KEY, noTemplateSource, true);
     checkRootNetworkExists(component);
+  });
+
+  it('prefills networks when importing - no networks', () => {
+    const props = undefined;
+    const stepData = {
+      [BASIC_SETTINGS_TAB_KEY]: {
+        value: {
+          [INTERMEDIARY_NETWORKS_TAB_KEY]: {
+            value: [],
+          },
+        },
+      },
+      [NETWORKS_TAB_KEY]: {
+        value: [],
+      },
+    };
+    const result = onVmwareVmChanged(props, stepData);
+    expect(result[NETWORKS_TAB_KEY].value).toHaveLength(0);
+  });
+
+  it('prefills networks when importing', () => {
+    const props = undefined;
+    const stepData = {
+      [BASIC_SETTINGS_TAB_KEY]: {
+        value: {
+          [INTERMEDIARY_NETWORKS_TAB_KEY]: {
+            value: [
+              {
+                name: 'nic0',
+                id: 'id0',
+                mac: 'some:mac:address:0',
+              },
+              {
+                name: 'nic1',
+                id: 'id1',
+                mac: 'some:mac:address:1',
+              },
+            ],
+          },
+        },
+      },
+      [NETWORKS_TAB_KEY]: {
+        value: [],
+      },
+    };
+    const result = onVmwareVmChanged(props, stepData);
+    expect(result[NETWORKS_TAB_KEY].value).toHaveLength(2);
+    expect(result[NETWORKS_TAB_KEY].value[0].importSourceId).toBe('id0');
+    expect(result[NETWORKS_TAB_KEY].value[0].name).toBe('nic0');
+    expect(result[NETWORKS_TAB_KEY].value[0].mac).toBe('some:mac:address:0');
+    expect(result[NETWORKS_TAB_KEY].value[0].network).toBe(undefined);
   });
 });
 


### PR DESCRIPTION
The `Networks` tab of the Create VM Wizard is filled by networks of the imported VMWare VM.

The user is expected to pair source networks with the target network configurations.
