### PR TITLE
Host status selector

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,5 +20,6 @@ export * from './components/ConfigurationSummary';
 // helpers
 export * from './constants';
 export * from './utils';
+export * from './models';
 export * from './k8s/request';
 export * from './k8s/selectors';

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -19,6 +19,19 @@ export const VirtualMachineModel = {
   id: 'virtualmachine',
 };
 
+export const BaremetalHostModel = {
+  label: 'Bare Metal Host',
+  labelPlural: 'Bare Metal Hosts',
+  apiVersion: 'v1alpha1',
+  path: 'baremetalhosts',
+  apiGroup: 'metalkube.org',
+  plural: 'baremetalhosts',
+  abbr: 'BMH',
+  namespaced: true,
+  kind: 'BareMetalHost',
+  id: 'baremetalhost',
+};
+
 export const ProcessedTemplatesModel = {
   apiVersion: 'v1',
   path: 'processedtemplates',

--- a/src/utils/selectors.js
+++ b/src/utils/selectors.js
@@ -156,3 +156,5 @@ export const isGuestAgentConnected = vmi =>
   get(vmi, 'status.conditions', []).some(
     condition => condition.type === 'AgentConnected' && condition.status === 'True'
   );
+
+export const getHostStatus = host => get(host, ['metadata', 'labels', 'metalkube.org/operational-status']);


### PR DESCRIPTION
This pull request adds BaremetalHostModel definition to models, introduces basic getHostStatus selector to be used with hosts filtering and determining host status.