### PR TITLE
Fix missing export error

### DIFF
--- a/src/utils/status/vm/vmStatus.js
+++ b/src/utils/status/vm/vmStatus.js
@@ -38,7 +38,7 @@ const getNotRedyConditionMessage = pod => {
 
 const findFailingContainerStatus = pod => getContainerStatuses(pod).find(isContainerFailing);
 
-const isBeingMigrated = (vm, migration) => {
+export const isBeingMigrated = (vm, migration) => {
   if (isMigrating(migration)) {
     return { status: VM_STATUS_MIGRATING, message: getMigrationStatusPhase(migration) };
   }


### PR DESCRIPTION
Export the isBeingMigrated function in vmStatus to fix a missing export error in the VM details dialog.