### PR TITLE
Fix cosmos

### DIFF
--- a/src/cosmos/proxies.js
+++ b/src/cosmos/proxies.js
@@ -1,1 +1,3 @@
 // https://github.com/react-cosmos/react-cosmos#proxies
+
+export default [];


### PR DESCRIPTION
Use empty array default proxy list.
Without this fix, cosmos 4.7 fails to load.