### PR TITLE
Render VmDetails with deleted template curreclty.

### DIFF
--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -4,6 +4,7 @@
 */
 
 @import './components/CancelAcceptButtons/cancel-accept-buttons';
+@import './components/Flavor/flavor';
 @import './components/Form/dropdown';
 @import './components/Form/form-group';
 @import './components/Form/list-form-factory';

--- a/sass/components/Flavor/flavor.scss
+++ b/sass/components/Flavor/flavor.scss
@@ -1,0 +1,3 @@
+.kubevirt-flavor__label {
+  margin-bottom: 7px;
+}

--- a/src/components/Details/Description/tests/__snapshots__/Description.test.js.snap
+++ b/src/components/Details/Description/tests/__snapshots__/Description.test.js.snap
@@ -21,6 +21,7 @@ exports[`<Description /> renders correctly 1`] = `
   }
   id="description"
   onFormChange={[Function]}
+  showLabels={false}
   updating={false}
 >
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lacus nibh, convallis vel nunc id,tempus vulputate augue. Proin eget nisl vel ante tincidunt accumsan vel at elit. Fusce eget tincidunt sem. Fusce cursus orci vitae nisl hendrerit mollis. Nullam at nulla ut ipsum malesuada laoreet a sit amet est.

--- a/src/components/Details/Flavor/Flavor.js
+++ b/src/components/Details/Flavor/Flavor.js
@@ -42,7 +42,7 @@ export class Flavor extends React.Component {
   };
 
   flavorFormFields = () => {
-    const { id, flavor } = this.props;
+    const { id } = this.props;
     const choices = this.getFlavorChoices();
 
     return {
@@ -50,7 +50,7 @@ export class Flavor extends React.Component {
         id: prefixedId(id, 'flavor-dropdown'),
         type: DROPDOWN,
         choices,
-        isVisible: () => choices.length > 1 || flavor !== CUSTOM_FLAVOR,
+        isVisible: () => choices.length > 1,
       },
       cpu: {
         id: prefixedId(id, 'flavor-cpu'),
@@ -76,11 +76,7 @@ export class Flavor extends React.Component {
 
     return (
       <Fragment>
-        {choices.length === 1 && flavor === CUSTOM_FLAVOR && editing ? (
-          <div className="kubevirt-flavor__label">{CUSTOM_FLAVOR}</div>
-        ) : (
-          ''
-        )}
+        {choices.length === 1 && editing ? <div className="kubevirt-flavor__label">{flavor}</div> : ''}
         <InlineEdit
           formFields={formFields}
           editing={editing}

--- a/src/components/Details/Flavor/fixtures/Flavor.fixture.js
+++ b/src/components/Details/Flavor/fixtures/Flavor.fixture.js
@@ -9,19 +9,18 @@ export default [
     component: Flavor,
     name: 'Flavor',
     props: {
+      id: 'Flavor',
       vm: cloudInitTestVm,
       flavor: getFlavor(cloudInitTestVm),
       onFormChange: () => {},
-      retrieveVmTemplate: () =>
-        new Promise(resolve => {
-          resolve(fedora28);
-        }),
+      template: null,
     },
   },
   {
     component: Flavor,
     name: 'Flavor editing',
     props: {
+      id: 'Flavor editing',
       vm: cloudInitTestVm,
       flavor: getFlavor(cloudInitTestVm),
       formValues: {
@@ -37,24 +36,19 @@ export default [
       },
       editing: true,
       onFormChange: () => {},
-      retrieveVmTemplate: () =>
-        new Promise(resolve => {
-          resolve(fedora28);
-        }),
+      template: fedora28,
     },
   },
   {
     component: Flavor,
     name: 'Flavor updating',
     props: {
+      id: 'Flavor updating',
       vm: cloudInitTestVm,
       flavor: getFlavor(cloudInitTestVm),
       updating: true,
       onFormChange: () => {},
-      retrieveVmTemplate: () =>
-        new Promise(resolve => {
-          resolve(fedora28);
-        }),
+      template: null,
     },
   },
 ];

--- a/src/components/Details/Flavor/tests/Flavor.test.js
+++ b/src/components/Details/Flavor/tests/Flavor.test.js
@@ -6,10 +6,16 @@ import { Flavor } from '..';
 import { default as FlavorFixture } from '../fixtures/Flavor.fixture';
 
 const testFlavor = () => <Flavor {...FlavorFixture[0].props} id="myflavor" />;
+const testFlavorEdit = () => <Flavor {...FlavorFixture[1].props} id="myflavor" />;
 
 describe('<Flavor />', () => {
   it('renders correctly', () => {
     const component = shallow(testFlavor());
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders edit view correctly', () => {
+    const component = shallow(testFlavorEdit());
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/Details/Flavor/tests/__snapshots__/Flavor.test.js.snap
+++ b/src/components/Details/Flavor/tests/__snapshots__/Flavor.test.js.snap
@@ -1,47 +1,115 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Flavor /> renders correctly 1`] = `
-<InlineEdit
-  LoadingComponent={[Function]}
-  editing={false}
-  fieldsValues={Object {}}
-  formFields={
-    Object {
-      "cpu": Object {
-        "id": "myflavor-flavor-cpu",
-        "isVisible": [Function],
-        "required": true,
-        "title": "CPU",
-        "type": "positive-number",
-      },
-      "flavor": Object {
-        "choices": Array [
-          "Custom",
-        ],
-        "id": "myflavor-flavor-dropdown",
-        "type": "dropdown",
-      },
-      "memory": Object {
-        "id": "myflavor-flavor-memory",
-        "isVisible": [Function],
-        "required": true,
-        "title": "Memory (GB)",
-        "type": "positive-number",
-      },
+<Fragment>
+  <InlineEdit
+    LoadingComponent={[Function]}
+    editing={false}
+    fieldsValues={Object {}}
+    formFields={
+      Object {
+        "cpu": Object {
+          "id": "myflavor-flavor-cpu",
+          "isVisible": [Function],
+          "required": true,
+          "title": "CPU",
+          "type": "positive-number",
+        },
+        "flavor": Object {
+          "choices": Array [
+            "Custom",
+            "small",
+          ],
+          "id": "myflavor-flavor-dropdown",
+          "isVisible": [Function],
+          "type": "dropdown",
+        },
+        "memory": Object {
+          "id": "myflavor-flavor-memory",
+          "isVisible": [Function],
+          "required": true,
+          "title": "Memory (GB)",
+          "type": "positive-number",
+        },
+      }
     }
-  }
-  onFormChange={[Function]}
-  updating={false}
->
-  <div
-    id="myflavor-flavor"
+    onFormChange={[Function]}
+    showLabels={true}
+    updating={false}
   >
-    small
-  </div>
-  <div
-    id="myflavor-flavor-description"
+    <div
+      id="myflavor-flavor"
+    >
+      small
+    </div>
+    <div
+      id="myflavor-flavor-description"
+    >
+      2 CPU, 2G Memory
+    </div>
+  </InlineEdit>
+</Fragment>
+`;
+
+exports[`<Flavor /> renders edit view correctly 1`] = `
+<Fragment>
+  <InlineEdit
+    LoadingComponent={[Function]}
+    editing={true}
+    fieldsValues={
+      Object {
+        "cpu": Object {
+          "value": "2",
+        },
+        "flavor": Object {
+          "value": "Custom",
+        },
+        "memory": Object {
+          "value": "2",
+        },
+      }
+    }
+    formFields={
+      Object {
+        "cpu": Object {
+          "id": "myflavor-flavor-cpu",
+          "isVisible": [Function],
+          "required": true,
+          "title": "CPU",
+          "type": "positive-number",
+        },
+        "flavor": Object {
+          "choices": Array [
+            "small",
+            "Custom",
+          ],
+          "id": "myflavor-flavor-dropdown",
+          "isVisible": [Function],
+          "type": "dropdown",
+        },
+        "memory": Object {
+          "id": "myflavor-flavor-memory",
+          "isVisible": [Function],
+          "required": true,
+          "title": "Memory (GB)",
+          "type": "positive-number",
+        },
+      }
+    }
+    onFormChange={[Function]}
+    showLabels={true}
+    updating={false}
   >
-    2 CPU, 2G Memory
-  </div>
-</InlineEdit>
+    <div
+      id="myflavor-flavor"
+    >
+      small
+    </div>
+    <div
+      id="myflavor-flavor-description"
+    >
+      2 CPU, 2G Memory
+    </div>
+  </InlineEdit>
+</Fragment>
 `;

--- a/src/components/Details/VmDetails/VmDetails.js
+++ b/src/components/Details/VmDetails/VmDetails.js
@@ -205,17 +205,20 @@ export class VmDetails extends React.Component {
         {this.state.k8sError && <Alert onDismiss={this.onErrorDismiss}>{this.state.k8sError}</Alert>}
       </Fragment>
     );
-    const titleWithWarning = (key, title, tooltipText) => {
+    const titleWithWarning = (key, title, error, tooltipText) => {
       const icon = <Icon name="warning" className="pficon-warning-triangle-o" />;
       const tooltip = <Tooltip id={`tooltip-${key}`}>{tooltipText}</Tooltip>;
-      return (
-        <Fragment>
-          <span className="kubevirt-vm-details-item-text">{title} </span>
-          <OverlayTrigger key="template" overlay={tooltip} placement="top">
-            {icon}
-          </OverlayTrigger>
-        </Fragment>
-      );
+      if (error) {
+        return (
+          <Fragment>
+            <span className="kubevirt-vm-details-item-text">{title} </span>
+            <OverlayTrigger key="template" overlay={tooltip} placement="top">
+              {icon}
+            </OverlayTrigger>
+          </Fragment>
+        );
+      }
+      return title;
     };
     const templateLink = () =>
       TemplateResourceLink ? <TemplateResourceLink template={template} /> : getTemplateDisplayName(template);
@@ -266,9 +269,12 @@ export class VmDetails extends React.Component {
               <dd id={prefixedId(id, 'workload-profile')}>{getWorkloadProfile(vm) || DASHES}</dd>
 
               <dt>
-                {this.state.templateError
-                  ? titleWithWarning('template', 'Template', 'This template is no longer available.')
-                  : 'Template'}
+                {titleWithWarning(
+                  'template',
+                  'Template',
+                  this.state.templateError,
+                  'This template is no longer available.'
+                )}
               </dt>
               <dd id={prefixedId(id, 'template')}>{template ? templateLink() : DASHES}</dd>
             </dl>

--- a/src/components/Details/VmDetails/fixtures/VmDetails.fixture.js
+++ b/src/components/Details/VmDetails/fixtures/VmDetails.fixture.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { VmDetails } from '../VmDetails';
 import { LABEL_USED_TEMPLATE_NAME, LABEL_USED_TEMPLATE_NAMESPACE } from '../../../../constants';
 import { k8sPatch, k8sGet } from '../../../../tests/k8s';
@@ -65,6 +67,35 @@ export const vmFixtures = {
         'flavor.template.cnv.io/small': 'true',
         'os.template.cnv.io/fedora29': 'true',
         [LABEL_USED_TEMPLATE_NAME]: 'fedora-generic',
+        [LABEL_USED_TEMPLATE_NAMESPACE]: 'default',
+        'workload.template.cnv.io/generic': 'true',
+      },
+    },
+    spec: {
+      template: {
+        spec: {
+          domain: {
+            cpu: {
+              cores: 2,
+            },
+            resources: {
+              requests: {
+                memory: '2G',
+              },
+            },
+          },
+        },
+      },
+      running: false,
+    },
+  },
+  vmWithDeletedTemplate: {
+    metadata: {
+      ...metadata,
+      labels: {
+        'flavor.template.cnv.io/small': 'true',
+        'os.template.cnv.io/fedora29': 'true',
+        [LABEL_USED_TEMPLATE_NAME]: 'deleted-template',
         [LABEL_USED_TEMPLATE_NAMESPACE]: 'default',
         'workload.template.cnv.io/generic': 'true',
       },
@@ -185,6 +216,17 @@ export default [
   },
   {
     component: VmDetails,
+    name: 'VM with flavor with template resource link',
+    props: {
+      vm: vmFixtures.vmWithLabels,
+      k8sPatch,
+      k8sGet,
+      NodeLink: () => true,
+      TemplateResourceLink: () => <a>default/fedora28</a>,
+    },
+  },
+  {
+    component: VmDetails,
     name: 'VM with custom flavor',
     props: {
       vm: vmFixtures.customVm,
@@ -202,6 +244,16 @@ export default [
       k8sGet,
       NodeLink: () => true,
       overview: true,
+    },
+  },
+  {
+    component: VmDetails,
+    name: 'VM detail with deleted template',
+    props: {
+      vm: vmFixtures.vmWithDeletedTemplate,
+      k8sPatch,
+      k8sGet,
+      NodeLink: () => true,
     },
   },
 ];

--- a/src/components/Details/VmDetails/tests/VmDetails.test.js
+++ b/src/components/Details/VmDetails/tests/VmDetails.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, mount } from 'enzyme';
 
+import { clickButton, flushPromises } from '../../../../tests/enzyme';
 import { cloudInitTestVmi } from '../../../../tests/mocks/vmi/cloudInitTestVmi.mock';
 import { VmDetails } from '../index';
 import { vmFixtures, default as VmDetailsFixture } from '../fixtures/VmDetails.fixture';
@@ -59,6 +60,23 @@ describe('<VmDetails />', () => {
   it('renders correctly as overview', () => {
     const component = render(testVmDetails(vmFixtures.runningVm, { overview: true }));
     expect(component).toMatchSnapshot();
+  });
+
+  it('renders deleted template correctly', async () => {
+    const component = mount(testVmDetails(vmFixtures.vmWithDeletedTemplate));
+    await flushPromises();
+    component.update();
+    expect(component.render()).toMatchSnapshot();
+  });
+});
+
+describe('<VmDetails /> edit', () => {
+  it('renders deleted template correctly', async () => {
+    const component = mount(testVmDetails(vmFixtures.vmWithDeletedTemplate));
+    clickButton(component, 'Edit');
+    await flushPromises();
+    component.update();
+    expect(component.render()).toMatchSnapshot();
   });
 });
 

--- a/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
+++ b/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
@@ -172,6 +172,188 @@ Array [
 ]
 `;
 
+exports[`<VmDetails /> edit renders deleted template correctly 1`] = `
+Array [
+  <h1
+    class="co-m-pane__heading"
+  >
+    Virtual Machine Overview
+    <div>
+      <button
+        class="btn btn-default"
+        type="button"
+      >
+        Edit
+      </button>
+    </div>
+  </h1>,
+  <div
+    class="kubevirt-vm-details__content"
+  >
+    <dl
+      class="kubevirt-vm-details__name-list"
+    >
+      <dt
+        class=""
+      >
+        Name
+      </dt>
+      <dd
+        class=""
+        id="my-namespace-my-vm-name"
+      >
+        my-vm
+      </dd>
+      <dt
+        class=""
+      >
+        Description
+      </dt>
+      <dd>
+        <div
+          class="kubevirt-vm-details__description"
+        >
+          <div
+            id="my-namespace-my-vm-description"
+          >
+            ---
+          </div>
+        </div>
+      </dd>
+    </dl>
+    <div
+      class="kubevirt-vm-details__details"
+    >
+      <dl
+        class="kubevirt-vm-details__details-list"
+      >
+        <dt>
+          Status
+        </dt>
+        <dd>
+          <div>
+            <span
+              aria-hidden="true"
+              class="kubevirt-vm-status__icon pficon pficon-off"
+            />
+            Off
+          </div>
+        </dd>
+        <dt>
+          Operating System
+        </dt>
+        <dd
+          id="my-namespace-my-vm-os"
+        >
+          fedora29
+        </dd>
+        <dt>
+          IP Addresses
+        </dt>
+        <dd
+          id="my-namespace-my-vm-ip-addresses"
+        >
+          ---
+        </dd>
+        <dt>
+          Workload Profile
+        </dt>
+        <dd
+          id="my-namespace-my-vm-workload-profile"
+        >
+          generic
+        </dd>
+        <dt>
+          <span
+            class="kubevirt-vm-details-item-text"
+          >
+            Template 
+          </span>
+          <span
+            aria-hidden="true"
+            class="fa fa-warning pficon-warning-triangle-o"
+          />
+        </dt>
+        <dd
+          id="my-namespace-my-vm-template"
+        >
+          default/deleted-template
+        </dd>
+      </dl>
+      <div
+        class="kubevirt-vm-details__other-details"
+      >
+        <dl
+          class="kubevirt-vm-details__details-list"
+        >
+          <dt>
+            FQDN
+          </dt>
+          <dd
+            id="my-namespace-my-vm-fqdn"
+          >
+            ---
+          </dd>
+          <dt>
+            Namespace
+          </dt>
+          <dd
+            id="my-namespace-my-vm-namespace"
+          >
+            ---
+          </dd>
+          <dt>
+            Pod
+          </dt>
+          <dd
+            id="my-namespace-my-vm-pod"
+          >
+            ---
+          </dd>
+          <dt>
+            Boot Order
+          </dt>
+          <dd
+            id="my-namespace-my-vm-boot-order"
+          >
+            ---
+          </dd>
+        </dl>
+        <dl
+          class="kubevirt-vm-details__details-list"
+        >
+          <dt>
+            Node
+          </dt>
+          <dd
+            id="my-namespace-my-vm-node"
+          >
+            ---
+          </dd>
+          <dt>
+            Flavor
+          </dt>
+          <dd>
+            <div>
+              <div
+                id="my-namespace-my-vm-flavor"
+              >
+                small
+              </div>
+              <div
+                id="my-namespace-my-vm-flavor-description"
+              >
+                2 CPU, 2G Memory
+              </div>
+            </div>
+          </dd>
+        </dl>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
 exports[`<VmDetails /> renders CPU and Memory settings for VM with custom flavor 1`] = `
 Array [
   <h1
@@ -895,6 +1077,188 @@ exports[`<VmDetails /> renders correctly as overview 1`] = `
     </div>
   </div>
 </div>
+`;
+
+exports[`<VmDetails /> renders deleted template correctly 1`] = `
+Array [
+  <h1
+    class="co-m-pane__heading"
+  >
+    Virtual Machine Overview
+    <div>
+      <button
+        class="btn btn-default"
+        type="button"
+      >
+        Edit
+      </button>
+    </div>
+  </h1>,
+  <div
+    class="kubevirt-vm-details__content"
+  >
+    <dl
+      class="kubevirt-vm-details__name-list"
+    >
+      <dt
+        class=""
+      >
+        Name
+      </dt>
+      <dd
+        class=""
+        id="my-namespace-my-vm-name"
+      >
+        my-vm
+      </dd>
+      <dt
+        class=""
+      >
+        Description
+      </dt>
+      <dd>
+        <div
+          class="kubevirt-vm-details__description"
+        >
+          <div
+            id="my-namespace-my-vm-description"
+          >
+            ---
+          </div>
+        </div>
+      </dd>
+    </dl>
+    <div
+      class="kubevirt-vm-details__details"
+    >
+      <dl
+        class="kubevirt-vm-details__details-list"
+      >
+        <dt>
+          Status
+        </dt>
+        <dd>
+          <div>
+            <span
+              aria-hidden="true"
+              class="kubevirt-vm-status__icon pficon pficon-off"
+            />
+            Off
+          </div>
+        </dd>
+        <dt>
+          Operating System
+        </dt>
+        <dd
+          id="my-namespace-my-vm-os"
+        >
+          fedora29
+        </dd>
+        <dt>
+          IP Addresses
+        </dt>
+        <dd
+          id="my-namespace-my-vm-ip-addresses"
+        >
+          ---
+        </dd>
+        <dt>
+          Workload Profile
+        </dt>
+        <dd
+          id="my-namespace-my-vm-workload-profile"
+        >
+          generic
+        </dd>
+        <dt>
+          <span
+            class="kubevirt-vm-details-item-text"
+          >
+            Template 
+          </span>
+          <span
+            aria-hidden="true"
+            class="fa fa-warning pficon-warning-triangle-o"
+          />
+        </dt>
+        <dd
+          id="my-namespace-my-vm-template"
+        >
+          default/deleted-template
+        </dd>
+      </dl>
+      <div
+        class="kubevirt-vm-details__other-details"
+      >
+        <dl
+          class="kubevirt-vm-details__details-list"
+        >
+          <dt>
+            FQDN
+          </dt>
+          <dd
+            id="my-namespace-my-vm-fqdn"
+          >
+            ---
+          </dd>
+          <dt>
+            Namespace
+          </dt>
+          <dd
+            id="my-namespace-my-vm-namespace"
+          >
+            ---
+          </dd>
+          <dt>
+            Pod
+          </dt>
+          <dd
+            id="my-namespace-my-vm-pod"
+          >
+            ---
+          </dd>
+          <dt>
+            Boot Order
+          </dt>
+          <dd
+            id="my-namespace-my-vm-boot-order"
+          >
+            ---
+          </dd>
+        </dl>
+        <dl
+          class="kubevirt-vm-details__details-list"
+        >
+          <dt>
+            Node
+          </dt>
+          <dd
+            id="my-namespace-my-vm-node"
+          >
+            ---
+          </dd>
+          <dt>
+            Flavor
+          </dt>
+          <dd>
+            <div>
+              <div
+                id="my-namespace-my-vm-flavor"
+              >
+                small
+              </div>
+              <div
+                id="my-namespace-my-vm-flavor-description"
+              >
+                2 CPU, 2G Memory
+              </div>
+            </div>
+          </dd>
+        </dl>
+      </div>
+    </div>
+  </div>,
+]
 `;
 
 exports[`<VmDetails /> renders description correctly 1`] = `

--- a/src/components/Details/VmTemplateDetails/VmTemplateDetails.js
+++ b/src/components/Details/VmTemplateDetails/VmTemplateDetails.js
@@ -163,17 +163,20 @@ export class VmTemplateDetails extends React.Component {
         </Button>
       </Fragment>
     );
-    const titleWithWarning = (key, title, tooltipText) => {
+    const titleWithWarning = (key, title, error, tooltipText) => {
       const icon = <Icon name="warning" className="pficon-warning-triangle-o" />;
       const tooltip = <Tooltip id={`tooltip-${key}`}>{tooltipText}</Tooltip>;
-      return (
-        <Fragment>
-          <span className="kubevirt-vm-details-item-text">{title} </span>
-          <OverlayTrigger key="template" overlay={tooltip} placement="top">
-            {icon}
-          </OverlayTrigger>
-        </Fragment>
-      );
+      if (error) {
+        return (
+          <Fragment>
+            <span className="kubevirt-vm-details-item-text">{title} </span>
+            <OverlayTrigger key="template" overlay={tooltip} placement="top">
+              {icon}
+            </OverlayTrigger>
+          </Fragment>
+        );
+      }
+      return title;
     };
 
     return (
@@ -216,9 +219,12 @@ export class VmTemplateDetails extends React.Component {
                   <dt>Workload Profile</dt>
                   <dd id={prefixedId(id, 'workload-profile')}>{getWorkloadProfile(vmTemplate) || DASHES}</dd>
                   <dt>
-                    {this.state.templateError
-                      ? titleWithWarning('template', 'Base Template', 'This template is no longer available.')
-                      : 'Base Template'}
+                    {titleWithWarning(
+                      'template',
+                      'Base Template',
+                      this.state.templateError,
+                      'This template is no longer available.'
+                    )}
                   </dt>
                   <dd id={prefixedId(id, 'base-template')}>{baseTemplateDisplayName}</dd>
                 </dl>

--- a/src/components/Details/VmTemplateDetails/VmTemplateDetails.js
+++ b/src/components/Details/VmTemplateDetails/VmTemplateDetails.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { Row, Col, Button, Alert } from 'patternfly-react';
+import { Row, Col, Button, Alert, Icon, Tooltip, OverlayTrigger } from 'patternfly-react';
 
 import {
   getCpu,
@@ -11,6 +11,7 @@ import {
   getOperatingSystemName,
   getFlavor,
   getVmTemplate,
+  getTemplateDisplayName,
   getId,
 } from '../../../selectors';
 import {
@@ -39,7 +40,9 @@ export class VmTemplateDetails extends React.Component {
       editing: false,
       updating: false,
       k8sError: null,
+      templateError: null,
       form: {},
+      baseTemplate: null,
     };
   }
 
@@ -61,11 +64,6 @@ export class VmTemplateDetails extends React.Component {
         },
       },
     }));
-
-  onLoadError = error =>
-    this.setState({
-      k8sError: error,
-    });
 
   updateVmDetails = () => {
     const { vmTemplate } = this.props;
@@ -116,6 +114,28 @@ export class VmTemplateDetails extends React.Component {
     }
   };
 
+  componentDidMount() {
+    const { k8sGet, vmTemplate } = this.props;
+    this.setState({
+      updating: true,
+    });
+    retrieveVmTemplate(k8sGet, vmTemplate)
+      .then(result => {
+        this.onFormChange('flavor', result, 'template', true);
+        return this.setState({
+          updating: false,
+          baseTemplate: result,
+        });
+      })
+      .catch(error =>
+        this.setState({
+          updating: false,
+          baseTemplate: null,
+          templateError: error.message || 'An error occurred. Please try again.',
+        })
+      );
+  }
+
   onErrorDismiss = () =>
     this.setState({
       k8sError: null,
@@ -124,10 +144,10 @@ export class VmTemplateDetails extends React.Component {
   isFormValid = () => Object.keys(this.state.form).every(key => this.state.form[key].valid);
 
   render() {
-    const { vmTemplate, dataVolumes, NamespaceResourceLink, LoadingComponent, k8sGet } = this.props;
+    const { vmTemplate, dataVolumes, NamespaceResourceLink, LoadingComponent } = this.props;
     const id = getId(vmTemplate);
     const vm = selectVm(vmTemplate.objects);
-    const baseTemplate = getVmTemplate(vmTemplate);
+    const baseTemplateDisplayName = getTemplateDisplayName(getVmTemplate(vmTemplate));
     const sortedBootableDevices = getBootableDevicesInOrder(vm);
 
     const editButton = (
@@ -143,6 +163,18 @@ export class VmTemplateDetails extends React.Component {
         </Button>
       </Fragment>
     );
+    const titleWithWarning = (key, title, tooltipText) => {
+      const icon = <Icon name="warning" className="pficon-warning-triangle-o" />;
+      const tooltip = <Tooltip id={`tooltip-${key}`}>{tooltipText}</Tooltip>;
+      return (
+        <Fragment>
+          <span className="kubevirt-vm-details-item-text">{title} </span>
+          <OverlayTrigger key="template" overlay={tooltip} placement="top">
+            {icon}
+          </OverlayTrigger>
+        </Fragment>
+      );
+    };
 
     return (
       <div className="co-m-pane__body">
@@ -183,10 +215,12 @@ export class VmTemplateDetails extends React.Component {
                   </dd>
                   <dt>Workload Profile</dt>
                   <dd id={prefixedId(id, 'workload-profile')}>{getWorkloadProfile(vmTemplate) || DASHES}</dd>
-                  <dt>Base Template</dt>
-                  <dd id={prefixedId(id, 'base-template')}>
-                    {baseTemplate ? `${baseTemplate.namespace}/${baseTemplate.name}` : DASHES}
-                  </dd>
+                  <dt>
+                    {this.state.templateError
+                      ? titleWithWarning('template', 'Base Template', 'This template is no longer available.')
+                      : 'Base Template'}
+                  </dt>
+                  <dd id={prefixedId(id, 'base-template')}>{baseTemplateDisplayName}</dd>
                 </dl>
               </Col>
 
@@ -218,9 +252,8 @@ export class VmTemplateDetails extends React.Component {
                       updating={this.state.updating}
                       LoadingComponent={LoadingComponent}
                       onFormChange={(newValue, key, valid) => this.onFormChange('flavor', newValue, key, valid)}
-                      retrieveVmTemplate={() => retrieveVmTemplate(k8sGet, vmTemplate)}
                       formValues={settingsValue(this.state.form, FLAVOR_KEY)}
-                      onLoadError={this.onLoadError}
+                      template={this.state.baseTemplate}
                     />
                   </dd>
                 </dl>

--- a/src/components/Details/VmTemplateDetails/fixtures/VmTemplateDetails.fixture.js
+++ b/src/components/Details/VmTemplateDetails/fixtures/VmTemplateDetails.fixture.js
@@ -1,6 +1,18 @@
+import { LABEL_USED_TEMPLATE_NAME } from '../../../../constants';
 import { VmTemplateDetails } from '../VmTemplateDetails';
-import { fedora28 } from '../../../../k8s/objects/template/fedora28';
 import { containerCloudTemplate, urlCustomFlavorTemplate } from '../../../../tests/mocks/user_template';
+import { k8sPatch, k8sGet } from '../../../../tests/k8s';
+
+const containerCloudDeletedTemplate = {
+  ...containerCloudTemplate,
+  metadata: {
+    ...containerCloudTemplate.metadata,
+    labels: {
+      ...containerCloudTemplate.metadata.labels,
+      [LABEL_USED_TEMPLATE_NAME]: 'deleted-template',
+    },
+  },
+};
 
 export default [
   {
@@ -9,14 +21,8 @@ export default [
     props: {
       vmTemplate: containerCloudTemplate,
       NamespaceResourceLink: () => containerCloudTemplate.metadata.namespace,
-      k8sPatch: () =>
-        new Promise(resolve => {
-          resolve();
-        }),
-      k8sGet: () =>
-        new Promise(resolve => {
-          resolve(fedora28);
-        }),
+      k8sPatch,
+      k8sGet,
     },
   },
   {
@@ -25,14 +31,18 @@ export default [
     props: {
       vmTemplate: urlCustomFlavorTemplate,
       NamespaceResourceLink: () => urlCustomFlavorTemplate.metadata.namespace,
-      k8sPatch: () =>
-        new Promise(resolve => {
-          resolve();
-        }),
-      k8sGet: () =>
-        new Promise(resolve => {
-          resolve(fedora28);
-        }),
+      k8sPatch,
+      k8sGet,
+    },
+  },
+  {
+    component: VmTemplateDetails,
+    name: 'Container VM Template with deleted base template',
+    props: {
+      vmTemplate: containerCloudDeletedTemplate,
+      NamespaceResourceLink: () => containerCloudDeletedTemplate.metadata.namespace,
+      k8sPatch,
+      k8sGet,
     },
   },
 ];

--- a/src/components/Details/VmTemplateDetails/tests/VmTemplateDetails.test.js
+++ b/src/components/Details/VmTemplateDetails/tests/VmTemplateDetails.test.js
@@ -2,7 +2,11 @@ import React from 'react';
 import { render, mount } from 'enzyme';
 
 import { VmTemplateDetails } from '../index';
-import { containerCloudTemplate, pxeDataVolumeTemplate } from '../../../../tests/mocks/user_template';
+import {
+  containerCloudTemplate,
+  pxeDataVolumeTemplate,
+  containerCloudDeletedTemplate,
+} from '../../../../tests/mocks/user_template';
 import { urlTemplate, urlTemplateDataVolume } from '../../../../tests/mocks/user_template/url.mock';
 import { default as VmTemplateDetailsFixture } from '../fixtures/VmTemplateDetails.fixture';
 import {
@@ -13,10 +17,21 @@ import {
   updatesFlavorOnSave,
 } from '../../common/tests/details';
 import { getId } from '../../../../selectors';
+import { flushPromises } from '../../../../tests/enzyme';
 
 const testVmTemplateDetails = (vmTemplate, props, dataVolumes = []) => (
   <VmTemplateDetails
     {...VmTemplateDetailsFixture[0].props}
+    vmTemplate={vmTemplate}
+    dataVolumes={dataVolumes}
+    NamespaceResourceLink={() => vmTemplate.metadata.namespace}
+    {...props}
+  />
+);
+
+const testVmDeletedTemplateDetails = (vmTemplate, props, dataVolumes = []) => (
+  <VmTemplateDetails
+    {...VmTemplateDetailsFixture[2].props}
     vmTemplate={vmTemplate}
     dataVolumes={dataVolumes}
     NamespaceResourceLink={() => vmTemplate.metadata.namespace}
@@ -38,6 +53,13 @@ describe('<VmTemplateDetails />', () => {
   it('renders pxe correctly', () => {
     const component = render(testVmTemplateDetails(pxeDataVolumeTemplate));
     expect(component).toMatchSnapshot();
+  });
+
+  it('renders container with deleted template correctly', async () => {
+    const component = mount(testVmDeletedTemplateDetails(containerCloudDeletedTemplate));
+    await flushPromises();
+    component.update();
+    expect(component.render()).toMatchSnapshot();
   });
 });
 

--- a/src/components/Details/VmTemplateDetails/tests/__snapshots__/VmTemplateDetails.test.js.snap
+++ b/src/components/Details/VmTemplateDetails/tests/__snapshots__/VmTemplateDetails.test.js.snap
@@ -165,6 +165,179 @@ exports[`<VmTemplateDetails /> renders container correctly 1`] = `
 </div>
 `;
 
+exports[`<VmTemplateDetails /> renders container with deleted template correctly 1`] = `
+<div
+  class="co-m-pane__body"
+>
+  <h1
+    class="co-m-pane__heading"
+  >
+    Virtual Machine Template Overview
+    <div>
+      <button
+        class="btn btn-default"
+        type="button"
+      >
+        Edit
+      </button>
+    </div>
+  </h1>
+  <div
+    class="row"
+  >
+    <div
+      class="col-lg-4 col-md-4 col-sm-4 col-xs-4"
+      id="name-description-column"
+    >
+      <dl>
+        <dt>
+          Name
+        </dt>
+        <dd
+          id="myproject-container-template-cloud-init-name"
+        >
+          container-template-cloud-init
+        </dd>
+        <dt>
+          Description
+        </dt>
+        <dd>
+          <div
+            class="kubevirt-vm-template-details__description"
+          >
+            <div
+              id="myproject-container-template-cloud-init-description"
+            >
+              ---
+            </div>
+          </div>
+        </dd>
+      </dl>
+    </div>
+    <div
+      class="col-lg-8 col-md-8 col-sm-8 col-xs-8"
+      id="details-column"
+    >
+      <div
+        class="row"
+      >
+        <div
+          class="col-lg-4 col-md-4 col-sm-4 col-xs-4"
+          id="details-column-1"
+        >
+          <dl>
+            <dt>
+              Operating System
+            </dt>
+            <dd
+              id="myproject-container-template-cloud-init-os"
+            >
+              Fedora 29
+            </dd>
+            <dt>
+              Workload Profile
+            </dt>
+            <dd
+              id="myproject-container-template-cloud-init-workload-profile"
+            >
+              generic
+            </dd>
+            <dt>
+              <span
+                class="kubevirt-vm-details-item-text"
+              >
+                Base Template 
+              </span>
+              <span
+                aria-hidden="true"
+                class="fa fa-warning pficon-warning-triangle-o"
+              />
+            </dt>
+            <dd
+              id="myproject-container-template-cloud-init-base-template"
+            >
+              default/deleted-template
+            </dd>
+          </dl>
+        </div>
+        <div
+          class="col-lg-4 col-md-4 col-sm-4 col-xs-4"
+          id="details-column-2"
+        >
+          <dl>
+            <dt>
+              Source
+            </dt>
+            <dd>
+              <div
+                class=""
+                id="myproject-container-template-cloud-init-type"
+                title="fooContainer"
+              >
+                Container
+              </div>
+              <div
+                class="kubevirt-template-source__source"
+                id="myproject-container-template-cloud-init-source"
+              >
+                fooContainer
+              </div>
+            </dd>
+            <dt>
+              Namespace
+            </dt>
+            <dd
+              id="myproject-container-template-cloud-init-namespace"
+            >
+              myproject
+            </dd>
+            <dd>
+              myproject
+            </dd>
+            <dt>
+              Boot Order
+            </dt>
+            <dd>
+              <ol
+                class="kubevirt-boot-order__list"
+              >
+                <li>
+                  rootdisk
+                </li>
+              </ol>
+            </dd>
+          </dl>
+        </div>
+        <div
+          class="col-lg-4 col-md-4 col-sm-4 col-xs-4"
+          id="details-column-3"
+        >
+          <dl>
+            <dt>
+              Flavor
+            </dt>
+            <dd>
+              <div>
+                <div
+                  id="myproject-container-template-cloud-init-flavor"
+                >
+                  small
+                </div>
+                <div
+                  id="myproject-container-template-cloud-init-flavor-description"
+                >
+                  2 CPU, 2G Memory
+                </div>
+              </div>
+            </dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<VmTemplateDetails /> renders pxe correctly 1`] = `
 <div
   class="co-m-pane__body"

--- a/src/components/InlineEdit/InlineEdit.js
+++ b/src/components/InlineEdit/InlineEdit.js
@@ -13,12 +13,20 @@ export const InlineEdit = ({
   onFormChange,
   fieldsValues,
   id,
+  showLabels,
 }) => {
   if (updating) {
     return <LoadingComponent id={id} />;
   }
   if (editing) {
-    return <InlineFormFactory fields={formFields} fieldsValues={fieldsValues} onFormChange={onFormChange} />;
+    return (
+      <InlineFormFactory
+        fields={formFields}
+        fieldsValues={fieldsValues}
+        onFormChange={onFormChange}
+        showLabels={showLabels}
+      />
+    );
   }
   return <div id={id}>{children}</div>;
 };
@@ -32,6 +40,7 @@ InlineEdit.propTypes = {
   onFormChange: PropTypes.func,
   fieldsValues: PropTypes.object,
   id: PropTypes.string,
+  showLabels: PropTypes.bool,
 };
 
 InlineEdit.defaultProps = {
@@ -42,4 +51,5 @@ InlineEdit.defaultProps = {
   onFormChange: () => {},
   fieldsValues: {},
   id: undefined,
+  showLabels: false,
 };

--- a/src/selectors/vm/selectors.js
+++ b/src/selectors/vm/selectors.js
@@ -10,6 +10,7 @@ import {
   TEMPLATE_WORKLOAD_LABEL,
   OS_WINDOWS_PREFIX,
   TEMPLATE_OS_NAME_ANNOTATION,
+  DASHES,
 } from '../../constants';
 
 export const getDisks = vm => get(vm, 'spec.template.spec.domain.devices.disks', []);
@@ -35,6 +36,7 @@ export const getVmTemplate = vm => {
   }
   return null;
 };
+export const getTemplateDisplayName = template => (template ? `${template.namespace}/${template.name}` : DASHES);
 export const getDescription = vm => get(vm, 'metadata.annotations.description');
 export const getCloudInitVolume = vm => {
   const volumes = getVolumes(vm);

--- a/src/tests/mocks/user_template/container-cloud.mock.js
+++ b/src/tests/mocks/user_template/container-cloud.mock.js
@@ -97,3 +97,14 @@ export const containerCloudTemplate = {
     },
   ],
 };
+
+export const containerCloudDeletedTemplate = {
+  ...containerCloudTemplate,
+  metadata: {
+    ...containerCloudTemplate.metadata,
+    labels: {
+      ...containerCloudTemplate.metadata.labels,
+      [LABEL_USED_TEMPLATE_NAME]: 'deleted-template',
+    },
+  },
+};

--- a/src/tests/mocks/user_template/index.js
+++ b/src/tests/mocks/user_template/index.js
@@ -1,5 +1,5 @@
 import { containerTemplate } from './container.mock';
-import { containerCloudTemplate } from './container-cloud.mock';
+import { containerCloudTemplate, containerCloudDeletedTemplate } from './container-cloud.mock';
 import { containerMultusTemplate } from './container-multus.mock';
 
 import { pvcTemplate } from './pvc.mock';
@@ -14,6 +14,7 @@ import { urlNoNetworkTemplate } from './url-nonetwork.mock';
 export {
   containerTemplate,
   containerCloudTemplate,
+  containerCloudDeletedTemplate,
   containerMultusTemplate,
   pvcTemplate,
   pxeTemplate,


### PR DESCRIPTION
**Description**
When we want to render VmDetails with missing VmTemplate we get a warning that we can not find the template. But It is OK to delete a template of an existing vm, the view should silently fall back to vm's current resources.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1685393

**Screenshots**

When template is missing, show warning triangle instead of an error:

![Peek 2019-03-31 14-35](https://user-images.githubusercontent.com/2181522/55288681-ac8a8c80-53c3-11e9-8381-5e0517b06073.gif)

Replace drop-down with a label when only one flavor option is available:

![Peek 2019-03-31 16-34](https://user-images.githubusercontent.com/2181522/55289927-49095a80-53d5-11e9-8ec2-95095e2ef76f.gif)

Add an optional template resource link method to vmDetails:

![Peek 2019-04-01 11-43](https://user-images.githubusercontent.com/2181522/55314707-64c33e00-5473-11e9-9dcb-eadc61c62fc6.gif)

Show labels for CPU and Memory in flavor form:

![Peek 2019-04-01 14-46](https://user-images.githubusercontent.com/2181522/55325218-0acf7200-548d-11e9-91b1-7d7aa46cd874.gif)
