### PR TITLE
Fix vmStatus ordering

### DIFF
--- a/src/utils/status/vm/vmStatus.js
+++ b/src/utils/status/vm/vmStatus.js
@@ -132,7 +132,8 @@ export const getVmStatus = (vm, pods, migrations, importerPods = null) => {
   const migration = findVMIMigration(migrations, vm);
   const vmImporterPods = getVmImporterPods(importerPods || pods, vm);
   return (
-    isBeingMigrated(vm, migration) || // must be precceding isRunning() since vm.status.ready is true for a migrating VM
+    isBeingMigrated(vm, migration) || // must precede isRunning() since vm.status.ready is true for a migrating VM
+    isBeingImported(vm, importerPods) || // must precede isRunning() since importing doesn't rely on the running status
     isRunning(vm) ||
     isReady(vm, launcherPod) ||
     isVmError(vm) ||


### PR DESCRIPTION
This PR changes the ordering of VM statuses in vmStatus to check importing status before running status to avoid the VM reflecting a status of "Off" when it is actually in "Importing" status.