### PR TITLE
Do not filter by namespace if vm is missing a namespace

### DIFF
--- a/src/components/CreateNicRow/CreateNicRow.js
+++ b/src/components/CreateNicRow/CreateNicRow.js
@@ -53,12 +53,12 @@ const getUsedNetworks = vm => {
   return usedNetworks;
 };
 
-const getNetworkChoices = (vm, networks) => {
+const getNetworkChoices = (vm, networks, namespace) => {
   const usedNetworks = getUsedNetworks(vm);
   const networkChoices = networks
     .filter(
       network =>
-        network.metadata.namespace === vm.metadata.namespace &&
+        (!namespace || network.metadata.namespace === namespace) &&
         !usedNetworks
           .filter(usedNetwork => usedNetwork.networkType === NETWORK_TYPE_MULTUS)
           .find(usedNetwork => usedNetwork.name === getName(network))
@@ -78,9 +78,10 @@ const getNetworkChoices = (vm, networks) => {
 
 const getNicColumns = (nic, networks, LoadingComponent) => {
   const bindingChoices = getNetworkBindings(get(settingsValue(nic, 'network'), 'networkType'));
+  const namespace = (nic.vm && nic.vm.metadata.namespace) || (nic.vmTemplate && nic.vmTemplate.metadata.namespace);
   let network;
   if (networks) {
-    const networkChoices = getNetworkChoices(nic.vm, networks);
+    const networkChoices = getNetworkChoices(nic.vm, networks, namespace);
     network = {
       id: 'network-type',
       type: DROPDOWN,

--- a/src/components/CreateNicRow/CreateNicRow.js
+++ b/src/components/CreateNicRow/CreateNicRow.js
@@ -53,12 +53,11 @@ const getUsedNetworks = vm => {
   return usedNetworks;
 };
 
-const getNetworkChoices = (vm, networks, namespace) => {
+const getNetworkChoices = (vm, networks) => {
   const usedNetworks = getUsedNetworks(vm);
   const networkChoices = networks
     .filter(
       network =>
-        (!namespace || network.metadata.namespace === namespace) &&
         !usedNetworks
           .filter(usedNetwork => usedNetwork.networkType === NETWORK_TYPE_MULTUS)
           .find(usedNetwork => usedNetwork.name === getName(network))
@@ -78,10 +77,9 @@ const getNetworkChoices = (vm, networks, namespace) => {
 
 const getNicColumns = (nic, networks, LoadingComponent) => {
   const bindingChoices = getNetworkBindings(get(settingsValue(nic, 'network'), 'networkType'));
-  const namespace = (nic.vm && nic.vm.metadata.namespace) || (nic.vmTemplate && nic.vmTemplate.metadata.namespace);
   let network;
   if (networks) {
-    const networkChoices = getNetworkChoices(nic.vm, networks, namespace);
+    const networkChoices = getNetworkChoices(nic.vm, networks);
     network = {
       id: 'network-type',
       type: DROPDOWN,

--- a/src/components/CreateNicRow/tests/CreateNicRow.test.js
+++ b/src/components/CreateNicRow/tests/CreateNicRow.test.js
@@ -101,6 +101,22 @@ describe('<CreateNicRow />', () => {
     ).toEqual(POD_NETWORK);
   });
 
+  it('falls back to template namespace when vm is missing namespace', () => {
+    const vm = cloneDeep(cloudInitTestVm);
+    delete vm.metadata.namespace;
+
+    const component = mount(testCreateNicRow(networkConfigs, { vm, vmTemplate: cloudInitTestVm }));
+    expect(getNetworkConfigs(component)).toHaveLength(1);
+  });
+
+  it('show all namespaces when vm and template do not have a namespace', () => {
+    const vm = cloneDeep(cloudInitTestVm);
+    delete vm.metadata.namespace;
+
+    const component = mount(testCreateNicRow(networkConfigs, { vm }));
+    expect(getNetworkConfigs(component)).toHaveLength(2);
+  });
+
   it('shows loading while getting network configs', () => {
     const component = mount(testCreateNicRow(undefined));
     expect(component.find(Loading).exists()).toBeTruthy();

--- a/src/components/CreateNicRow/tests/CreateNicRow.test.js
+++ b/src/components/CreateNicRow/tests/CreateNicRow.test.js
@@ -9,7 +9,7 @@ import { Dropdown } from '../../Form/Dropdown';
 import CreateNicRowFixture from '../fixtures/CreateNicRow.fixture';
 import { networkConfigs } from '../../../tests/mocks/networkAttachmentDefinition';
 import { cloudInitTestVm } from '../../../tests/mocks/vm/cloudInitTestVm.mock';
-import { getName, getNamespace } from '../../../selectors';
+import { getName } from '../../../selectors';
 import { Loading } from '../../Loading';
 import { POD_NETWORK } from '../../../constants';
 
@@ -34,11 +34,7 @@ describe('<CreateNicRow />', () => {
       vm: cloudInitTestVm,
     };
 
-    // Filter networkConfigs for nic's namespace (should be done in caller component),
-    // we assume networkConfigs include only currect namespaced networks.
-    const filteredNetworkConfig = networkConfigs.filter(network => getNamespace(network) === getNamespace(nic.vm));
-
-    const component = mount(testCreateNicRow(filteredNetworkConfig, nic));
+    const component = mount(testCreateNicRow([networkConfigs[0]], nic));
     expect(getNetworkConfigs(component)).toHaveLength(1);
     expect(
       getNetworkConfigs(component)

--- a/src/components/CreateNicRow/tests/CreateNicRow.test.js
+++ b/src/components/CreateNicRow/tests/CreateNicRow.test.js
@@ -34,10 +34,11 @@ describe('<CreateNicRow />', () => {
       vm: cloudInitTestVm,
     };
 
-    // Filter networkConfigs for nic's namespace (should be done in caller component)
-    const component = mount(
-      testCreateNicRow(networkConfigs.filter(network => getNamespace(network === getNamespace(nic.vm)), nic))
-    );
+    // Filter networkConfigs for nic's namespace (should be done in caller component),
+    // we assume networkConfigs include only currect namespaced networks.
+    const filteredNetworkConfig = networkConfigs.filter(network => getNamespace(network) === getNamespace(nic.vm));
+
+    const component = mount(testCreateNicRow(filteredNetworkConfig, nic));
     expect(getNetworkConfigs(component)).toHaveLength(1);
     expect(
       getNetworkConfigs(component)

--- a/src/components/CreateNicRow/tests/CreateNicRow.test.js
+++ b/src/components/CreateNicRow/tests/CreateNicRow.test.js
@@ -9,7 +9,7 @@ import { Dropdown } from '../../Form/Dropdown';
 import CreateNicRowFixture from '../fixtures/CreateNicRow.fixture';
 import { networkConfigs } from '../../../tests/mocks/networkAttachmentDefinition';
 import { cloudInitTestVm } from '../../../tests/mocks/vm/cloudInitTestVm.mock';
-import { getName } from '../../../selectors';
+import { getName, getNamespace } from '../../../selectors';
 import { Loading } from '../../Loading';
 import { POD_NETWORK } from '../../../constants';
 
@@ -34,7 +34,10 @@ describe('<CreateNicRow />', () => {
       vm: cloudInitTestVm,
     };
 
-    const component = mount(testCreateNicRow(networkConfigs, nic));
+    // Filter networkConfigs for nic's namespace (should be done in caller component)
+    const component = mount(
+      testCreateNicRow(networkConfigs.filter(network => getNamespace(network === getNamespace(nic.vm)), nic))
+    );
     expect(getNetworkConfigs(component)).toHaveLength(1);
     expect(
       getNetworkConfigs(component)
@@ -99,22 +102,6 @@ describe('<CreateNicRow />', () => {
         .find('a')
         .text()
     ).toEqual(POD_NETWORK);
-  });
-
-  it('falls back to template namespace when vm is missing namespace', () => {
-    const vm = cloneDeep(cloudInitTestVm);
-    delete vm.metadata.namespace;
-
-    const component = mount(testCreateNicRow(networkConfigs, { vm, vmTemplate: cloudInitTestVm }));
-    expect(getNetworkConfigs(component)).toHaveLength(1);
-  });
-
-  it('show all namespaces when vm and template do not have a namespace', () => {
-    const vm = cloneDeep(cloudInitTestVm);
-    delete vm.metadata.namespace;
-
-    const component = mount(testCreateNicRow(networkConfigs, { vm }));
-    expect(getNetworkConfigs(component)).toHaveLength(2);
   });
 
   it('shows loading while getting network configs', () => {


### PR DESCRIPTION
Currently when vm is missing a namespace we do not show any nic, we want to show all namespaces when not namespace is defined.

Ref: https://github.com/kubevirt/web-ui/pull/265

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1687917