### PR TITLE
Change Font size and Units in Capacity card

### DIFF
--- a/src/components/ClusterOverview/Capacity/tests/__snapshots__/Capacity.test.js.snap
+++ b/src/components/ClusterOverview/Capacity/tests/__snapshots__/Capacity.test.js.snap
@@ -22,11 +22,11 @@ exports[`<Capacity /> renders correctly 1`] = `
       <div
         class="kubevirt-capacity__item"
       >
-        <h2
+        <h3
           class="kubevirt-capacity__item-title"
         >
           CPU
-        </h2>
+        </h3>
         <h6>
           50 % available out of 100 %
         </h6>
@@ -39,13 +39,13 @@ exports[`<Capacity /> renders correctly 1`] = `
       <div
         class="kubevirt-capacity__item"
       >
-        <h2
+        <h3
           class="kubevirt-capacity__item-title"
         >
           Memory
-        </h2>
+        </h3>
         <h6>
-          1.0 MB available out of 1 MB
+          1.0 MiB available out of 1 MiB
         </h6>
         <div>
           <div
@@ -56,11 +56,11 @@ exports[`<Capacity /> renders correctly 1`] = `
       <div
         class="kubevirt-capacity__item"
       >
-        <h2
+        <h3
           class="kubevirt-capacity__item-title"
         >
           Storage
-        </h2>
+        </h3>
         <h6>
           5 B available out of 10 B
         </h6>
@@ -73,11 +73,11 @@ exports[`<Capacity /> renders correctly 1`] = `
       <div
         class="kubevirt-capacity__item"
       >
-        <h2
+        <h3
           class="kubevirt-capacity__item-title"
         >
           Network
-        </h2>
+        </h3>
         <h6>
           5 Bps available out of 10 Bps
         </h6>
@@ -114,11 +114,11 @@ exports[`<Capacity /> renders correctly in Loading state 1`] = `
       <div
         class="kubevirt-capacity__item"
       >
-        <h2
+        <h3
           class="kubevirt-capacity__item-title"
         >
           CPU
-        </h2>
+        </h3>
         <h6>
           <div>
             <div
@@ -135,11 +135,11 @@ exports[`<Capacity /> renders correctly in Loading state 1`] = `
       <div
         class="kubevirt-capacity__item"
       >
-        <h2
+        <h3
           class="kubevirt-capacity__item-title"
         >
           Memory
-        </h2>
+        </h3>
         <h6>
           <div>
             <div
@@ -156,11 +156,11 @@ exports[`<Capacity /> renders correctly in Loading state 1`] = `
       <div
         class="kubevirt-capacity__item"
       >
-        <h2
+        <h3
           class="kubevirt-capacity__item-title"
         >
           Storage
-        </h2>
+        </h3>
         <h6>
           <div>
             <div
@@ -177,11 +177,11 @@ exports[`<Capacity /> renders correctly in Loading state 1`] = `
       <div
         class="kubevirt-capacity__item"
       >
-        <h2
+        <h3
           class="kubevirt-capacity__item-title"
         >
           Network
-        </h2>
+        </h3>
         <h6>
           <div>
             <div

--- a/src/components/ClusterOverview/Utilization/tests/__snapshots__/Utilization.test.js.snap
+++ b/src/components/ClusterOverview/Utilization/tests/__snapshots__/Utilization.test.js.snap
@@ -62,7 +62,7 @@ exports[`<Utilization /> renders correctly 1`] = `
           <div
             class="kubevirt-utilization__item-actual col-lg-6 col-md-6 col-sm-6 col-xs-6"
           >
-            30 KB
+            30 KiB
           </div>
         </div>
         <div

--- a/src/components/Dashboard/Capacity/CapacityItem.js
+++ b/src/components/Dashboard/Capacity/CapacityItem.js
@@ -46,7 +46,7 @@ export const CapacityItem = ({ id, title, used, total, unit, formatValue, Loadin
   // TODO(mlibra): align text font
   return (
     <div className="kubevirt-capacity__item">
-      <h2 className="kubevirt-capacity__item-title">{title}</h2>
+      <h3 className="kubevirt-capacity__item-title">{title}</h3>
       <h6>{description}</h6>
       <div>
         <DonutChart

--- a/src/components/Dashboard/Capacity/tests/__snapshots__/CapacityItem.test.js.snap
+++ b/src/components/Dashboard/Capacity/tests/__snapshots__/CapacityItem.test.js.snap
@@ -4,11 +4,11 @@ exports[`<CapacityItem /> renders correctly 1`] = `
 <div
   className="kubevirt-capacity__item"
 >
-  <h2
+  <h3
     className="kubevirt-capacity__item-title"
   >
     title
-  </h2>
+  </h3>
   <h6>
     50 unit available out of 100 unit
   </h6>
@@ -82,11 +82,11 @@ exports[`<CapacityItem /> renders correctly 2`] = `
 <div
   className="kubevirt-capacity__item"
 >
-  <h2
+  <h3
     className="kubevirt-capacity__item-title"
   >
     title
-  </h2>
+  </h3>
   <h6>
     <InlineLoading
       size="md"
@@ -162,11 +162,11 @@ exports[`<CapacityItem /> renders correctly 3`] = `
 <div
   className="kubevirt-capacity__item"
 >
-  <h2
+  <h3
     className="kubevirt-capacity__item-title"
   >
     title
-  </h2>
+  </h3>
   <h6>
     Not available
   </h6>

--- a/src/components/StorageOverview/Capacity/tests/__snapshots__/Capacity.test.js.snap
+++ b/src/components/StorageOverview/Capacity/tests/__snapshots__/Capacity.test.js.snap
@@ -22,11 +22,11 @@ exports[`<Capacity /> renders correctly 1`] = `
       <div
         class="kubevirt-capacity__item"
       >
-        <h2
+        <h3
           class="kubevirt-capacity__item-title"
         >
           Total capacity
-        </h2>
+        </h3>
         <h6>
           <div>
             <div
@@ -67,11 +67,11 @@ exports[`<Capacity /> renders correctly in Loading state 1`] = `
       <div
         class="kubevirt-capacity__item"
       >
-        <h2
+        <h3
           class="kubevirt-capacity__item-title"
         >
           Total capacity
-        </h2>
+        </h3>
         <h6>
           <div>
             <div

--- a/src/utils/tests/utils.test.js
+++ b/src/utils/tests/utils.test.js
@@ -3,21 +3,21 @@ import { formatBytes, formatCores, formatNetTraffic } from '../utils';
 describe('unit format functions', () => {
   it('formats bytes', () => {
     expect(formatBytes(2)).toEqual({ value: 2, unit: 'B' });
-    expect(formatBytes(3 * 1024)).toEqual({ value: 3, unit: 'KB' });
-    expect(formatBytes(3 * 1024 ** 2)).toEqual({ value: 3, unit: 'MB' });
-    expect(formatBytes(3 * 1024 ** 3)).toEqual({ value: 3, unit: 'GB' });
-    expect(formatBytes(3 * 1024 ** 4)).toEqual({ value: 3, unit: 'TB' });
-    expect(formatBytes(3 * 1024 ** 5)).toEqual({ value: 3, unit: 'PB' });
-    expect(formatBytes(3 * 1024 ** 6)).toEqual({ value: 3 * 1024, unit: 'PB' });
-    expect(formatBytes(3 * 1024 ** 7)).toEqual({ value: 3 * 1024 ** 2, unit: 'PB' });
+    expect(formatBytes(3 * 1024)).toEqual({ value: 3, unit: 'KiB' });
+    expect(formatBytes(3 * 1024 ** 2)).toEqual({ value: 3, unit: 'MiB' });
+    expect(formatBytes(3 * 1024 ** 3)).toEqual({ value: 3, unit: 'GiB' });
+    expect(formatBytes(3 * 1024 ** 4)).toEqual({ value: 3, unit: 'TiB' });
+    expect(formatBytes(3 * 1024 ** 5)).toEqual({ value: 3, unit: 'PiB' });
+    expect(formatBytes(3 * 1024 ** 6)).toEqual({ value: 3 * 1024, unit: 'PiB' });
+    expect(formatBytes(3 * 1024 ** 7)).toEqual({ value: 3 * 1024 ** 2, unit: 'PiB' });
   });
   it('formats bytes in preferred units', () => {
-    expect(formatBytes(3 * 1024 * 1024, 'KB')).toEqual({ value: 3 * 1024, unit: 'KB' });
+    expect(formatBytes(3 * 1024 * 1024, 'KiB')).toEqual({ value: 3 * 1024, unit: 'KiB' });
   });
   it('formats cores', () => {
     expect(formatCores(2)).toEqual({ value: 2, unit: 'cores' });
   });
   it('formats net traffic', () => {
-    expect(formatNetTraffic(3 * 1024 * 1024)).toEqual({ value: 3, unit: 'MBps' });
+    expect(formatNetTraffic(3 * 1024 * 1024)).toEqual({ value: 3, unit: 'MiBps' });
   });
 });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -84,15 +84,15 @@ export const getResource = (
 
 const BYTE_UNITS = {
   B: 0,
-  KB: 1,
-  MB: 2,
-  GB: 3,
-  TB: 4,
-  PB: 5,
+  KiB: 1,
+  MiB: 2,
+  GiB: 3,
+  TiB: 4,
+  PiB: 5,
 };
 
 export const formatBytes = (bytes, unit, fixed = 2) => {
-  unit = unit || Object.keys(BYTE_UNITS).find(key => bytes < 1024 ** (BYTE_UNITS[key] + 1)) || 'PB';
+  unit = unit || Object.keys(BYTE_UNITS).find(key => bytes < 1024 ** (BYTE_UNITS[key] + 1)) || 'PiB';
   return { value: Number((bytes / 1024 ** BYTE_UNITS[unit]).toFixed(fixed)), unit };
 };
 


### PR DESCRIPTION
Changes done-
1. Font size of 'Total capacity' reduced as it shouldn't be larger than the card title. This also maintains consistency across cards in terms of aesthetics.
2. Units changed from GB to GiB and so on.

Before-
![Screenshot from 2019-04-09 16-17-01](https://user-images.githubusercontent.com/27074500/55795888-65e51280-5ae6-11e9-8a43-a794e1c0e882.png)

After-
![Screenshot from 2019-04-09 16-36-47](https://user-images.githubusercontent.com/27074500/55795903-70071100-5ae6-11e9-8b7c-e1112ff4d271.png)

