### PR TITLE
Add Alerts Card

### DIFF
--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -26,6 +26,7 @@
 @import './components/Dashboard/utilization';
 @import './components/Dashboard/consumers';
 @import './components/Dashboard/events';
+@import './components/Dashboard/alert';
 @import './components/ClusterOverview/cluster-overview';
 @import './components/ClusterOverview/health';
 @import './components/ClusterOverview/compliance';

--- a/sass/components/ClusterOverview/cluster-overview.scss
+++ b/sass/components/ClusterOverview/cluster-overview.scss
@@ -12,3 +12,17 @@
   justify-content: space-between;
   align-items: center;
 }
+
+.kubevirt-cluster-overview__health-grid {
+  margin: 1em;
+
+  /* stylelint-disable plugin/selector-bem-pattern */
+  .kubevirt-dashboard__card {
+    margin: 0;
+  }
+  /* stylelint-enable */
+}
+
+.kubevirt-cluster-overview__card--top-border {
+  border-top: 1px solid #d1d1d1;
+}

--- a/sass/components/Dashboard/alert.scss
+++ b/sass/components/Dashboard/alert.scss
@@ -1,0 +1,26 @@
+.kubevirt-alert__alerts-body {
+  max-height: 10em;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.kubevirt-alert__item {
+  margin-bottom: 0.5em;
+  display: table;
+}
+
+.kubevirt-alert__item-message {
+  display: table-cell;
+}
+
+.kubevirt-alert__icon {
+  margin-right: 1.5em;
+}
+
+.kubevirt-alert__icon--critical {
+  color: red;
+}
+
+.kubevirt-alert__icon--warning {
+  color: goldenrod;
+}

--- a/src/components/ClusterOverview/Alerts/Alerts.js
+++ b/src/components/ClusterOverview/Alerts/Alerts.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  DashboardCard,
+  DashboardCardBody,
+  DashboardCardHeader,
+  DashboardCardTitle,
+} from '../../Dashboard/DashboardCard';
+import { ClusterOverviewContext } from '../ClusterOverviewContext';
+import { AlertsBody } from '../../Dashboard/Alert/AlertsBody';
+import { filterAlerts } from './utils';
+import { AlertItem } from '../../Dashboard/Alert/AlertItem';
+
+export const Alerts = ({ alertsResponse, className }) => {
+  if (!Array.isArray(alertsResponse)) {
+    return null;
+  }
+
+  const alerts = filterAlerts(alertsResponse);
+
+  return alerts.length > 0 ? (
+    <DashboardCard className={className}>
+      <DashboardCardHeader>
+        <DashboardCardTitle>Alerts</DashboardCardTitle>
+      </DashboardCardHeader>
+      <DashboardCardBody>
+        <AlertsBody>
+          {alerts.map((alert, index) => (
+            <AlertItem key={`alert-${index}`} alert={alert} />
+          ))}
+        </AlertsBody>
+      </DashboardCardBody>
+    </DashboardCard>
+  ) : null;
+};
+
+Alerts.propTypes = {
+  alertsResponse: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  className: PropTypes.string,
+};
+
+Alerts.defaultProps = {
+  alertsResponse: null,
+  className: null,
+};
+
+export const AlertsConnected = ({ className }) => (
+  <ClusterOverviewContext.Consumer>
+    {props => <Alerts alertsResponse={props.alertsResponse} className={className} />}
+  </ClusterOverviewContext.Consumer>
+);
+
+AlertsConnected.propTypes = {
+  ...Alerts.propTypes,
+};
+
+AlertsConnected.defaultProps = {
+  ...Alerts.defaultProps,
+};

--- a/src/components/ClusterOverview/Alerts/fixtures/Alerts.fixture.js
+++ b/src/components/ClusterOverview/Alerts/fixtures/Alerts.fixture.js
@@ -1,0 +1,14 @@
+import { Alerts } from '../Alerts';
+import {
+  criticalAlert,
+  unknownTypeAlert,
+  warningAlert,
+  watchDogAlert,
+} from '../../../Dashboard/Alert/fixtures/AlertItem.fixture';
+
+export default {
+  component: Alerts,
+  props: {
+    alertsResponse: [criticalAlert, unknownTypeAlert, warningAlert, watchDogAlert],
+  },
+};

--- a/src/components/ClusterOverview/Alerts/tests/Alerts.test.js
+++ b/src/components/ClusterOverview/Alerts/tests/Alerts.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { Alerts } from '../Alerts';
+import { default as AlertsFixtures } from '../fixtures/Alerts.fixture';
+
+const testAlerts = () => <Alerts {...AlertsFixtures.props} />;
+
+describe('<Alerts />', () => {
+  it('renders correctly', () => {
+    const component = shallow(testAlerts());
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/ClusterOverview/Alerts/tests/__snapshots__/Alerts.test.js.snap
+++ b/src/components/ClusterOverview/Alerts/tests/__snapshots__/Alerts.test.js.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Alerts /> renders correctly 1`] = `
+<DashboardCard
+  className={null}
+>
+  <DashboardCardHeader
+    className={null}
+  >
+    <DashboardCardTitle>
+      Alerts
+    </DashboardCardTitle>
+  </DashboardCardHeader>
+  <DashboardCardBody
+    LoadingComponent={[Function]}
+    isLoading={false}
+  >
+    <AlertsBody>
+      <AlertItem
+        alert={
+          Object {
+            "annotations": Object {
+              "message": "Critical alert",
+            },
+            "labels": Object {
+              "alertname": "fooName",
+              "severity": "critical",
+            },
+          }
+        }
+        key="alert-0"
+      />
+      <AlertItem
+        alert={
+          Object {
+            "annotations": Object {
+              "message": "unknown type alert",
+            },
+            "labels": Object {
+              "alertname": "fooName",
+              "severity": "unknown",
+            },
+          }
+        }
+        key="alert-1"
+      />
+      <AlertItem
+        alert={
+          Object {
+            "annotations": Object {
+              "message": "20% of the metrics targets are down.",
+            },
+            "labels": Object {
+              "alertname": "TargetDown",
+              "severity": "warning",
+            },
+          }
+        }
+        key="alert-2"
+      />
+    </AlertsBody>
+  </DashboardCardBody>
+</DashboardCard>
+`;

--- a/src/components/ClusterOverview/Alerts/utils.js
+++ b/src/components/ClusterOverview/Alerts/utils.js
@@ -1,0 +1,3 @@
+import { get } from 'lodash';
+
+export const filterAlerts = alerts => alerts.filter(alert => get(alert, 'labels.alertname') !== 'Watchdog');

--- a/src/components/ClusterOverview/ClusterOverview.js
+++ b/src/components/ClusterOverview/ClusterOverview.js
@@ -14,15 +14,23 @@ import { InventoryConnected } from './Inventory/Inventory';
 import { CapacityConnected } from './Capacity/Capacity';
 import { UtilizationConnected } from './Utilization/Utilization';
 import { TopConsumersConnected } from './TopConsumers/TopConsumers';
+import { AlertsConnected } from './Alerts/Alerts';
 
 const MainCards = () => (
   <GridItem lg={6} md={12} sm={12}>
     <Grid>
-      <GridItem span={6}>
-        <HealthConnected />
-      </GridItem>
-      <GridItem span={6}>
-        <ComplianceConnected />
+      <GridItem span={12}>
+        <Grid className="kubevirt-cluster-overview__health-grid">
+          <GridItem span={6}>
+            <HealthConnected />
+          </GridItem>
+          <GridItem span={6}>
+            <ComplianceConnected />
+          </GridItem>
+          <GridItem span={12}>
+            <AlertsConnected className="kubevirt-cluster-overview__card--top-border" />
+          </GridItem>
+        </Grid>
       </GridItem>
       <GridItem span={12}>
         <CapacityConnected />

--- a/src/components/ClusterOverview/fixtures/ClusterOverview.fixture.js
+++ b/src/components/ClusterOverview/fixtures/ClusterOverview.fixture.js
@@ -18,6 +18,7 @@ import { persistentVolumeClaims } from '../../../tests/mocks/persistentVolumeCla
 import { cloudInitTestVm } from '../../../tests/mocks/vm/cloudInitTestVm.mock';
 import { fullVm } from '../../../tests/mocks/vm/vm.mock';
 import { cloudInitTestVmi } from '../../../tests/mocks/vmi/cloudInitTestVmi.mock';
+import { warningAlert, unknownTypeAlert, criticalAlert } from '../../Dashboard/Alert/fixtures/AlertItem.fixture';
 
 export const nodes = [localhostNode];
 export const pvcs = persistentVolumeClaims;
@@ -60,6 +61,26 @@ export default [
       eventsData: { loaded: false },
       utilizationStats: { loaded: false },
       inventoryData: { loaded: false },
+    },
+  },
+  {
+    component: ClusterOverview,
+    name: 'Overview with alerts',
+    props: {
+      ...clusterDetailsData,
+      healthData,
+      ...capacityStats,
+      complianceData,
+      eventsData,
+      utilizationStats,
+      ...consumersData,
+      nodes,
+      pvcs,
+      pods,
+      vms,
+      vmis,
+      migrations,
+      alertsResponse: [warningAlert, unknownTypeAlert, criticalAlert],
     },
   },
 ];

--- a/src/components/Dashboard/Alert/AlertItem.js
+++ b/src/components/Dashboard/Alert/AlertItem.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon } from 'patternfly-react';
+
+import { getAlertSeverity, getAlertMessage } from '../../../selectors/prometheus';
+
+const getSeverityIcon = severity => {
+  switch (severity) {
+    case 'critical':
+      return (
+        <Icon type="fa" name="exclamation-circle" className="kubevirt-alert__icon kubevirt-alert__icon--critical" />
+      );
+    case 'warning':
+    default:
+      return (
+        <Icon type="fa" name="exclamation-triangle" className="kubevirt-alert__icon kubevirt-alert__icon--warning" />
+      );
+  }
+};
+
+export const AlertItem = ({ alert }) => (
+  <div className="kubevirt-alert__item">
+    {getSeverityIcon(getAlertSeverity(alert))}
+    <div className="kubevirt-alert__item-message">{getAlertMessage(alert)}</div>
+  </div>
+);
+
+AlertItem.propTypes = {
+  alert: PropTypes.object.isRequired,
+};

--- a/src/components/Dashboard/Alert/AlertsBody.js
+++ b/src/components/Dashboard/Alert/AlertsBody.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const AlertsBody = ({ children }) => <div className="kubevirt-alert__alerts-body">{children}</div>;
+
+AlertsBody.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+};

--- a/src/components/Dashboard/Alert/fixtures/AlertItem.fixture.js
+++ b/src/components/Dashboard/Alert/fixtures/AlertItem.fixture.js
@@ -1,0 +1,65 @@
+import { AlertItem } from '../AlertItem';
+
+export const warningAlert = {
+  annotations: {
+    message: '20% of the metrics targets are down.',
+  },
+  labels: {
+    alertname: 'TargetDown',
+    severity: 'warning',
+  },
+};
+
+export const watchDogAlert = {
+  annotations: {
+    message: 'This is an alert meant to ensure that the entire alerting pipeline is functional',
+  },
+  labels: {
+    alertname: 'Watchdog',
+    severity: 'none',
+  },
+};
+
+export const criticalAlert = {
+  annotations: {
+    message: 'Critical alert',
+  },
+  labels: {
+    alertname: 'fooName',
+    severity: 'critical',
+  },
+};
+
+export const unknownTypeAlert = {
+  annotations: {
+    message: 'unknown type alert',
+  },
+  labels: {
+    alertname: 'fooName',
+    severity: 'unknown',
+  },
+};
+
+export default [
+  {
+    component: AlertItem,
+    name: 'Warning alert item',
+    props: {
+      alert: warningAlert,
+    },
+  },
+  {
+    component: AlertItem,
+    name: 'Critical alert item',
+    props: {
+      alert: criticalAlert,
+    },
+  },
+  {
+    component: AlertItem,
+    name: 'Unknown alert item',
+    props: {
+      alert: unknownTypeAlert,
+    },
+  },
+];

--- a/src/components/Dashboard/Alert/fixtures/AlertsBody.fixture.js
+++ b/src/components/Dashboard/Alert/fixtures/AlertsBody.fixture.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { AlertsBody } from '../AlertsBody';
+import { criticalAlert, unknownTypeAlert, warningAlert } from './AlertItem.fixture';
+import { AlertItem } from '../AlertItem';
+
+export default {
+  component: AlertsBody,
+  props: {
+    children: [
+      <AlertItem key="1" alert={criticalAlert} />,
+      <AlertItem key="2" alert={unknownTypeAlert} />,
+      <AlertItem key="3" alert={warningAlert} />,
+    ],
+  },
+};

--- a/src/components/Dashboard/Alert/tests/AlertItem.test.js
+++ b/src/components/Dashboard/Alert/tests/AlertItem.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { AlertItem } from '../AlertItem';
+import { default as AlertItemFixtures } from '../fixtures/AlertItem.fixture';
+
+const testAlertItem = () => <AlertItem {...AlertItemFixtures[0].props} />;
+
+describe('<AlertItem />', () => {
+  it('renders correctly', () => {
+    const component = shallow(testAlertItem());
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/Dashboard/Alert/tests/AlertsBody.test.js
+++ b/src/components/Dashboard/Alert/tests/AlertsBody.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { AlertsBody } from '../AlertsBody';
+import { default as AlertsBodyFixtures } from '../fixtures/AlertsBody.fixture';
+
+const testAlertsBody = () => <AlertsBody {...AlertsBodyFixtures.props} />;
+
+describe('<AlertsBody />', () => {
+  it('renders correctly', () => {
+    const component = shallow(testAlertsBody());
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/Dashboard/Alert/tests/__snapshots__/AlertItem.test.js.snap
+++ b/src/components/Dashboard/Alert/tests/__snapshots__/AlertItem.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AlertItem /> renders correctly 1`] = `
+<div
+  className="kubevirt-alert__item"
+>
+  <Icon
+    className="kubevirt-alert__icon kubevirt-alert__icon--warning"
+    name="exclamation-triangle"
+    type="fa"
+  />
+  <div
+    className="kubevirt-alert__item-message"
+  >
+    20% of the metrics targets are down.
+  </div>
+</div>
+`;

--- a/src/components/Dashboard/Alert/tests/__snapshots__/AlertsBody.test.js.snap
+++ b/src/components/Dashboard/Alert/tests/__snapshots__/AlertsBody.test.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AlertsBody /> renders correctly 1`] = `
+<div
+  className="kubevirt-alert__alerts-body"
+>
+  <AlertItem
+    alert={
+      Object {
+        "annotations": Object {
+          "message": "Critical alert",
+        },
+        "labels": Object {
+          "alertname": "fooName",
+          "severity": "critical",
+        },
+      }
+    }
+    key="1"
+  />
+  <AlertItem
+    alert={
+      Object {
+        "annotations": Object {
+          "message": "unknown type alert",
+        },
+        "labels": Object {
+          "alertname": "fooName",
+          "severity": "unknown",
+        },
+      }
+    }
+    key="2"
+  />
+  <AlertItem
+    alert={
+      Object {
+        "annotations": Object {
+          "message": "20% of the metrics targets are down.",
+        },
+        "labels": Object {
+          "alertname": "TargetDown",
+          "severity": "warning",
+        },
+      }
+    }
+    key="3"
+  />
+</div>
+`;

--- a/src/selectors/prometheus/alerts.js
+++ b/src/selectors/prometheus/alerts.js
@@ -1,0 +1,4 @@
+import { get } from 'lodash';
+
+export const getAlertSeverity = alert => get(alert, 'labels.severity');
+export const getAlertMessage = alert => get(alert, 'annotations.message');

--- a/src/selectors/prometheus/index.js
+++ b/src/selectors/prometheus/index.js
@@ -1,2 +1,3 @@
 export * from './cluster';
 export * from './selectors';
+export * from './alerts';


### PR DESCRIPTION
![alerts](https://user-images.githubusercontent.com/2078045/55798552-8786cf80-5acf-11e9-837b-163c56a77657.png)

According to design we should have a dropdown which would allow filtering alerts by severity. Severity is defined by labels and label values can be anything so its up to alert creator to set the key and value. For this reason Im not adding dropdown yet. I try to recognize critical alerts by looking for label `severity: critical`. All others are evaluated as `warning` severity