### PR TITLE
Add default host status when host does not have status data

### DIFF
--- a/src/selectors/host/selectors.js
+++ b/src/selectors/host/selectors.js
@@ -7,3 +7,4 @@ export const getHostRole = hostMachine =>
   get(hostMachine, ['metadata', 'labels', 'machine.openshift.io/cluster-api-machine-role']);
 
 export const getHostMachineName = host => get(host, 'spec.machineRef.name');
+export const getHostErrorMessage = host => get(host, 'status.errorMessage');

--- a/src/utils/status/host/hostStatus.js
+++ b/src/utils/status/host/hostStatus.js
@@ -1,17 +1,17 @@
-import { getOperationalStatus, getProvisioningState } from '../../../selectors';
+import { getOperationalStatus, getProvisioningState, getHostErrorMessage } from '../../../selectors';
 
-import { HOST_STATUS_TO_TEXT, HOST_STATUS_READY } from './constants';
+import { HOST_STATUS_TO_TEXT, HOST_STATUS_READY, HOST_STATUS_REGISTERING } from './constants';
 
 export const getHostStatus = host => {
   // Returns a status string based on the available host information.
   const operationalStatus = getOperationalStatus(host);
   const provisioningState = getProvisioningState(host);
 
-  const hostStatus = provisioningState || operationalStatus;
+  const hostStatus = provisioningState || operationalStatus || HOST_STATUS_REGISTERING;
   return {
     status: hostStatus,
     text: HOST_STATUS_TO_TEXT[hostStatus] || hostStatus,
-    errorMessage: host.status.errorMessage,
+    errorMessage: getHostErrorMessage(host),
   };
 };
 


### PR DESCRIPTION
This fixes the problem when retrieving host status when there is no host.status data available