### PR TITLE
Render Add Host link as host status when in discovered state

### DIFF
--- a/src/components/BareMetalHosts/BaremetalHostStatus.js
+++ b/src/components/BareMetalHosts/BaremetalHostStatus.js
@@ -2,9 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { getHostStatus } from '../../utils/status/host/hostStatus';
-import { GenericStatus, GenericError, GenericProgress, GenericSuccess, ValidationError } from './StatusComponents';
+import {
+  AddDiscoveredHostLink,
+  GenericStatus,
+  GenericError,
+  GenericProgress,
+  GenericSuccess,
+  ValidationError,
+} from './StatusComponents';
 import {
   HOST_STATUS_VALIDATION_ERROR,
+  HOST_STATUS_DISCOVERED,
   HOST_STATUS_ALL_PROGRESS,
   HOST_STATUS_ALL_ERROR,
   HOST_STATUS_ALL_SUCCESS,
@@ -18,6 +26,8 @@ export const BaremetalHostStatus = ({ host, machine, nodes }) => {
   switch (true) {
     case status === HOST_STATUS_VALIDATION_ERROR:
       return <ValidationError {...hostStatus} />;
+    case status === HOST_STATUS_DISCOVERED:
+      return <AddDiscoveredHostLink host={host} />;
     case HOST_STATUS_ALL_PROGRESS.includes(status):
       return <GenericProgress {...hostStatus} />;
     case HOST_STATUS_ALL_SUCCESS.includes(status):

--- a/src/components/BareMetalHosts/StatusComponents.js
+++ b/src/components/BareMetalHosts/StatusComponents.js
@@ -68,3 +68,9 @@ ValidationError.propTypes = {
   text: PropTypes.string.isRequired,
   errorMessage: PropTypes.string.isRequired,
 };
+
+export const AddDiscoveredHostLink = host => (
+  <a>
+    <IconAndText icon="add-circle-o" text="Add host" />
+  </a>
+);

--- a/src/components/BareMetalHosts/fixtures/BaremetalHostStatus.fixture.js
+++ b/src/components/BareMetalHosts/fixtures/BaremetalHostStatus.fixture.js
@@ -20,4 +20,5 @@ export default [
   createFixture('Show progress state for `match profile` status', 'match profile'),
   createFixture('Show error state for `provisioning error` status', 'provisioning error'),
   createFixture('Show error state for `power management error` status', 'power management error'),
+  createFixture('Show add host link for `discovered` status', 'discovered'),
 ];

--- a/src/components/BareMetalHosts/fixtures/StatusComponents.fixture.js
+++ b/src/components/BareMetalHosts/fixtures/StatusComponents.fixture.js
@@ -1,4 +1,11 @@
-import { GenericError, GenericProgress, GenericSuccess, GenericStatus, ValidationError } from '../StatusComponents';
+import {
+  GenericError,
+  GenericProgress,
+  GenericSuccess,
+  GenericStatus,
+  ValidationError,
+  AddDiscoveredHostLink,
+} from '../StatusComponents';
 
 export default [
   {
@@ -49,6 +56,14 @@ export default [
     props: {
       status: 'provisioned',
       text: 'Provisioned',
+    },
+  },
+  {
+    component: AddDiscoveredHostLink,
+    name: 'Show AddDiscoveredHostLink',
+    props: {
+      status: 'discovered',
+      text: 'Add host',
     },
   },
 ];

--- a/src/components/BareMetalHosts/tests/StatusComponents.test.js
+++ b/src/components/BareMetalHosts/tests/StatusComponents.test.js
@@ -1,7 +1,14 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { GenericError, GenericProgress, GenericSuccess, GenericStatus, ValidationError } from '../StatusComponents';
+import {
+  GenericError,
+  GenericProgress,
+  GenericSuccess,
+  GenericStatus,
+  ValidationError,
+  AddDiscoveredHostLink,
+} from '../StatusComponents';
 
 import StatusComponentsFixture from '../fixtures/StatusComponents.fixture';
 
@@ -11,6 +18,7 @@ const testGenericSuccess = () => <GenericSuccess {...StatusComponentsFixture[2].
 const testGenericErrorWithDetails = () => <GenericError {...StatusComponentsFixture[3].props} />;
 const testValidationError = () => <ValidationError {...StatusComponentsFixture[4].props} />;
 const testGenericStatus = () => <GenericStatus {...StatusComponentsFixture[5].props} />;
+const testAddDiscoveredHostLink = () => <AddDiscoveredHostLink {...StatusComponentsFixture[6].props} />;
 
 describe('<GenericProgress />', () => {
   it('renders a progress message', () => {
@@ -45,6 +53,12 @@ describe('<ValidationError />', () => {
 describe('<GenericStatus />', () => {
   it('renders a generic status string', () => {
     const component = shallow(testGenericStatus());
+    expect(component).toMatchSnapshot();
+  });
+});
+describe('<AddDiscoveredHostLink />', () => {
+  it('renders a link to add discovered host', () => {
+    const component = shallow(testAddDiscoveredHostLink());
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/BareMetalHosts/tests/__snapshots__/BaremetalHostStatus.test.js.snap
+++ b/src/components/BareMetalHosts/tests/__snapshots__/BaremetalHostStatus.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<BaremetalHostStatus /> renders the correct subcomponent for the "discovered" state (5) 1`] = `
+<AddDiscoveredHostLink
+  host={
+    Object {
+      "status": Object {
+        "provisioning": Object {
+          "state": "discovered",
+        },
+      },
+    }
+  }
+/>
+`;
+
 exports[`<BaremetalHostStatus /> renders the correct subcomponent for the "match profile" state (2) 1`] = `
 <GenericProgress
   status="match profile"

--- a/src/components/BareMetalHosts/tests/__snapshots__/StatusComponents.test.js.snap
+++ b/src/components/BareMetalHosts/tests/__snapshots__/StatusComponents.test.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<AddDiscoveredHostLink /> renders a link to add discovered host 1`] = `
+<a>
+  <IconAndText
+    icon="add-circle-o"
+    text="Add host"
+  />
+</a>
+`;
+
 exports[`<GenericError /> renders an error message 1`] = `
 <IconAndText
   icon="error-circle-o"


### PR DESCRIPTION
This adds a temporary placeholder link which should in future point
to dialog which lets user register a newly discovered host