### PR TITLE
Correct creation text for VM templates

### DIFF
--- a/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
@@ -473,7 +473,7 @@ export class CreateVmWizard extends React.Component {
       render: () => {
         const stepData = this.state.stepData[RESULT_TAB_KEY];
         return (
-          <ResultTab isSuccessful={stepData.valid} createTemplate={this.props.createTemplate}>
+          <ResultTab isSuccessful={stepData.valid} isCreateTemplate={this.props.createTemplate}>
             {stepData.value.map((result, index) => (
               <ResultTabRow key={index} {...result} />
             ))}
@@ -488,6 +488,7 @@ export class CreateVmWizard extends React.Component {
     const lastStepReached = this.lastStepReached();
 
     const createVmText = this.props.createTemplate ? CREATE_VM_TEMPLATE : CREATE_VM;
+
     return (
       <Wizard.Pattern
         show


### PR DESCRIPTION
The confirmation message upon successful creation of a VM template was incorrectly being displayed as "Creation of VM was successful" as reported in [1]. This PR corrects the creation text to display "Creation of VM template was successful".

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1697816