### PR TITLE
Correct hostname display in VM overview tab

### DIFF
--- a/src/components/Details/VmDetails/VmDetails.js
+++ b/src/components/Details/VmDetails/VmDetails.js
@@ -16,10 +16,10 @@ import {
   getWorkloadProfile,
   getVmiIpAddresses,
   getOperatingSystemName,
-  getHostName,
   getFlavor,
   getId,
   getDescription,
+  getHostname,
 } from '../../../selectors';
 import {
   getUpdateDescriptionPatch,
@@ -179,8 +179,7 @@ export class VmDetails extends React.Component {
     const vmIsOff = isVmOff(vmStatus);
     const nodeName = getNodeName(launcherPod);
     const ipAddresses = vmIsOff ? [] : getVmiIpAddresses(vmi);
-    const hostName = getHostName(launcherPod);
-    const fqdn = vmIsOff || !hostName ? DASHES : hostName;
+    const hostname = (!vmIsOff && getHostname(vmi)) || DASHES;
     const template = getVmTemplate(vm);
     const id = getId(vm);
     const sortedBootableDevices = getBootableDevicesInOrder(vm);
@@ -288,8 +287,8 @@ export class VmDetails extends React.Component {
             </dl>
             <div className="kubevirt-vm-details__other-details">
               <dl className="kubevirt-vm-details__details-list">
-                <dt>FQDN</dt>
-                <dd id={prefixedId(id, 'fqdn')}>{fqdn}</dd>
+                <dt>Hostname</dt>
+                <dd id={prefixedId(id, 'hostname')}>{hostname}</dd>
 
                 <dt>Namespace</dt>
                 <dd id={prefixedId(id, 'namespace')}>{NamespaceResourceLink ? <NamespaceResourceLink /> : DASHES}</dd>

--- a/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
+++ b/src/components/Details/VmDetails/tests/__snapshots__/VmDetails.test.js.snap
@@ -107,10 +107,10 @@ Array [
           class="kubevirt-vm-details__details-list"
         >
           <dt>
-            FQDN
+            Hostname
           </dt>
           <dd
-            id="my-namespace-my-vm-fqdn"
+            id="my-namespace-my-vm-hostname"
           >
             ---
           </dd>
@@ -304,10 +304,10 @@ Array [
           class="kubevirt-vm-details__details-list"
         >
           <dt>
-            FQDN
+            Hostname
           </dt>
           <dd
-            id="my-namespace-my-vm-fqdn"
+            id="my-namespace-my-vm-hostname"
           >
             ---
           </dd>
@@ -495,10 +495,10 @@ Array [
           class="kubevirt-vm-details__details-list"
         >
           <dt>
-            FQDN
+            Hostname
           </dt>
           <dd
-            id="my-namespace-my-vm-fqdn"
+            id="my-namespace-my-vm-hostname"
           >
             ---
           </dd>
@@ -700,10 +700,10 @@ Array [
           class="kubevirt-vm-details__details-list"
         >
           <dt>
-            FQDN
+            Hostname
           </dt>
           <dd
-            id="my-namespace-my-vm-fqdn"
+            id="my-namespace-my-vm-hostname"
           >
             ---
           </dd>
@@ -907,10 +907,10 @@ Array [
           class="kubevirt-vm-details__details-list"
         >
           <dt>
-            FQDN
+            Hostname
           </dt>
           <dd
-            id="my-namespace-my-vm-fqdn"
+            id="my-namespace-my-vm-hostname"
           >
             ---
           </dd>
@@ -1082,10 +1082,10 @@ exports[`<VmDetails /> renders correctly as overview 1`] = `
         class="kubevirt-vm-details__details-list"
       >
         <dt>
-          FQDN
+          Hostname
         </dt>
         <dd
-          id="my-namespace-my-vm-fqdn"
+          id="my-namespace-my-vm-hostname"
         >
           ---
         </dd>
@@ -1288,10 +1288,10 @@ Array [
           class="kubevirt-vm-details__details-list"
         >
           <dt>
-            FQDN
+            Hostname
           </dt>
           <dd
-            id="my-namespace-my-vm-fqdn"
+            id="my-namespace-my-vm-hostname"
           >
             ---
           </dd>
@@ -1483,10 +1483,10 @@ Array [
           class="kubevirt-vm-details__details-list"
         >
           <dt>
-            FQDN
+            Hostname
           </dt>
           <dd
-            id="my-namespace-my-vm-fqdn"
+            id="my-namespace-my-vm-hostname"
           >
             ---
           </dd>
@@ -1674,10 +1674,10 @@ Array [
           class="kubevirt-vm-details__details-list"
         >
           <dt>
-            FQDN
+            Hostname
           </dt>
           <dd
-            id="my-namespace-my-vm-fqdn"
+            id="my-namespace-my-vm-hostname"
           >
             ---
           </dd>
@@ -1863,10 +1863,10 @@ Array [
           class="kubevirt-vm-details__details-list"
         >
           <dt>
-            FQDN
+            Hostname
           </dt>
           <dd
-            id="my-namespace-my-vm-fqdn"
+            id="my-namespace-my-vm-hostname"
           >
             ---
           </dd>
@@ -2066,10 +2066,10 @@ Array [
           class="kubevirt-vm-details__details-list"
         >
           <dt>
-            FQDN
+            Hostname
           </dt>
           <dd
-            id="my-namespace-my-vm-fqdn"
+            id="my-namespace-my-vm-hostname"
           >
             ---
           </dd>
@@ -2273,10 +2273,10 @@ Array [
           class="kubevirt-vm-details__details-list"
         >
           <dt>
-            FQDN
+            Hostname
           </dt>
           <dd
-            id="my-namespace-my-vm-fqdn"
+            id="my-namespace-my-vm-hostname"
           >
             ---
           </dd>

--- a/src/selectors/vmi/selectors.js
+++ b/src/selectors/vmi/selectors.js
@@ -9,6 +9,8 @@ export const getVmiIpAddresses = vmi =>
     .map(i => i.ipAddress)
     .filter(ip => ip && ip.trim().length > 0);
 
+export const getHostname = vmi => get(vmi, 'spec.hostname');
+
 export const isGuestAgentConnected = vmi =>
   get(vmi, 'status.conditions', []).some(
     condition => condition.type === 'AgentConnected' && condition.status === 'True'


### PR DESCRIPTION
This PR does the following:

- Changes the "FQDN" label to "Hostname" in the VM overview tab
- If cloud init is used and hostname field is populated, sets vmi.spec.hostname to the hostname provided
- Sets vmi.spec.hostname to the VM name is cloud init isn't being used or the hostname field is empty

Bug: https://bugzilla.redhat.com/1688124