### PR TITLE
bug fix: progress bar showing resiliency percentage above 100%

### DIFF
--- a/src/components/StorageOverview/DataResiliency/DataResiliency.js
+++ b/src/components/StorageOverview/DataResiliency/DataResiliency.js
@@ -58,7 +58,7 @@ export const DataResiliency = ({ totalPgRaw, cleanAndActivePgRaw, LoadingCompone
         isLoading={!(totalPgRaw && cleanAndActivePgRaw)}
         LoadingComponent={LoadingComponent}
       >
-        {progressPercentage === 100 || !progressPercentage ? (
+        {progressPercentage >= 100 || !progressPercentage ? (
           <DataResiliencyStatusBody isResilient={progressPercentage} />
         ) : (
           <DataResiliencyBuildBody progressPercentage={progressPercentage} />


### PR DESCRIPTION
due to the lag in updation of values for `totalPg` and `cleanAndActivePg` the progress percentage gets calculated above 100% sometimes.

![bug](https://user-images.githubusercontent.com/25664409/56534939-4a631880-6578-11e9-9fa6-375517481089.png)
