### PR TITLE
Fixed the x-axis sequence issue for top projects card

### DIFF
--- a/src/components/StorageOverview/TopConsumers/TopConsumers.js
+++ b/src/components/StorageOverview/TopConsumers/TopConsumers.js
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-charts';
 
 import { InlineLoading } from '../../Loading';
+import { formatToShortTime } from '../../../utils';
 
 import {
   DashboardCard,
@@ -29,7 +30,7 @@ const TopConsumersBody = ({ topConsumerStats }) => {
 
   if (topConsumerStats.length) {
     const stats = getTopConsumerVectorStats(topConsumerStats);
-    const { chartData, legends, xAxisData, maxCapacity, unit } = stats;
+    const { chartData, legends, maxCapacity, unit } = stats;
     const yTickValues = [
       0,
       Number((maxCapacity / 4).toFixed(1)),
@@ -57,9 +58,10 @@ const TopConsumersBody = ({ topConsumerStats }) => {
                   labelComponent={<ChartTooltip style={{ fontSize: 8, padding: 5 }} />}
                 />
               }
+              scale={{ x: 'time' }}
             >
               <ChartGroup>{chartLineList}</ChartGroup>
-              <ChartAxis tickValues={xAxisData} style={{ tickLabels: { fontSize: 8, padding: 5 } }} />
+              <ChartAxis tickFormat={x => formatToShortTime(x)} style={{ tickLabels: { fontSize: 8, padding: 5 } }} />
               <ChartAxis
                 label={`Requested capacity(${unit})`}
                 dependentAxis

--- a/src/selectors/prometheus/storage.js
+++ b/src/selectors/prometheus/storage.js
@@ -1,6 +1,6 @@
 import { flatMap, max } from 'lodash';
 
-import { parseNumber, formatBytes, formatToShortTime } from '../../utils';
+import { parseNumber, formatBytes } from '../../utils';
 
 export const getTopConsumerVectorStats = result => {
   let maxVal = 0;
@@ -9,20 +9,6 @@ export const getTopConsumerVectorStats = result => {
   const allBytes = flatMap(namespaceValues, value => parseNumber(value[1]));
   maxVal = max(allBytes);
   const maxCapacityConverted = { ...formatBytes(maxVal) };
-
-  let largestLengthArray = 0;
-  let largestLengthArrayIndex = 0;
-  // timestamps count and values are not same for all the namespaces. Hence, finding the largest length array and taking its timestamps value as x-axis point
-  result.forEach((namespace, index) => {
-    const len = namespace.values.length;
-    if (len > largestLengthArray) {
-      largestLengthArray = len;
-      largestLengthArrayIndex = index;
-    }
-  });
-  const xAxisData = [
-    ...result[largestLengthArrayIndex].values.map(array => formatToShortTime(new Date(array[0] * 1000))),
-  ];
 
   const sortNamespaces = (a, b) => {
     let isALarger = 0;
@@ -41,17 +27,13 @@ export const getTopConsumerVectorStats = result => {
   const legends = sortedResult.map(r => ({ name: r.metric.namespace }));
 
   const chartData = sortedResult.map(r =>
-    r.values.map(arr => [
-      formatToShortTime(new Date(arr[0] * 1000)),
-      formatBytes(arr[1], maxCapacityConverted.unit, 2).value,
-    ])
+    r.values.map(arr => [new Date(arr[0] * 1000), formatBytes(arr[1], maxCapacityConverted.unit, 2).value])
   );
 
   // sorting namespaces to maintain the order of legends displayed for chart
   const stats = {
     chartData,
     legends,
-    xAxisData,
     maxCapacity: Number(maxCapacityConverted.value),
     unit: maxCapacityConverted.unit,
   };


### PR DESCRIPTION
Description - The x-axis was not plotting the time in sequence if the timestamps aren't same for all namespaces for top projects card.

Before : 
![top-projects-bug](https://user-images.githubusercontent.com/5517376/56578702-39aeb300-6609-11e9-8a27-c6e9f096ca87.png)

After fixing:
![top-projects-fixed](https://user-images.githubusercontent.com/5517376/56579157-6a431c80-660a-11e9-8975-3f23457bce4d.png)
