### PR TITLE
Fix baremetal status popover

### DIFF
--- a/config/cosmos.webpack.config.js
+++ b/config/cosmos.webpack.config.js
@@ -43,7 +43,8 @@ module.exports = {
       {
         test: /\.(jpg|jpeg|png|gif|svg|eot|otf|ttf|woff|woff2)$/,
         loader: 'file-loader',
-      },{
+      },
+      {
         test: /\.css$/,
         use: ['style-loader', 'css-loader'],
       },

--- a/config/cosmos.webpack.config.js
+++ b/config/cosmos.webpack.config.js
@@ -44,6 +44,16 @@ module.exports = {
         test: /\.(jpg|jpeg|png|gif|svg|eot|otf|ttf|woff|woff2)$/,
         loader: 'file-loader',
       },
+      {
+        test: /\.css$/,
+        exclude: /node_modules/,
+        use: ['style-loader', 'css-loader'],
+      },
+      {
+        test: /\.css$/,
+        include: /node_modules/,
+        use: ['style-loader', 'css-loader'],
+      },
     ],
   },
 };

--- a/config/cosmos.webpack.config.js
+++ b/config/cosmos.webpack.config.js
@@ -43,15 +43,8 @@ module.exports = {
       {
         test: /\.(jpg|jpeg|png|gif|svg|eot|otf|ttf|woff|woff2)$/,
         loader: 'file-loader',
-      },
-      {
+      },{
         test: /\.css$/,
-        exclude: /node_modules/,
-        use: ['style-loader', 'css-loader'],
-      },
-      {
-        test: /\.css$/,
-        include: /node_modules/,
         use: ['style-loader', 'css-loader'],
       },
     ],

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -26,6 +26,9 @@ module.exports = {
       transformIgnorePatterns: ['node_modules/(?!(@novnc))'],
       setupFiles: [`${paths.src}/jest/setupTest.js`],
       snapshotSerializers: ['enzyme-to-json/serializer'],
+      moduleNameMapper: {
+        '\\.(css|scss)$': `${paths.config}/jest.style.mock.js`,
+      },
     },
 
     {

--- a/config/jest.style.mock.js
+++ b/config/jest.style.mock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "@patternfly/react-charts": "2.x",
-    "@patternfly/react-core": "3.16.16",
+    "@patternfly/react-core": "3.16.x",
     "patternfly-react": "2.x",
     "prop-types": "15.x",
     "react": "16.6.x",
@@ -60,7 +60,7 @@
     "@babel/preset-env": "7.x",
     "@babel/preset-react": "7.x",
     "@patternfly/react-charts": "2.x",
-    "@patternfly/react-core": "3.16.16",
+    "@patternfly/react-core": "3.16.x",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.x",
     "babel-jest": "24.x",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "coveralls": "shx cat coverage/lcov.info | coveralls"
   },
   "peerDependencies": {
-    "@patternfly/react-core": "1.43.x",
     "@patternfly/react-charts": "2.x",
+    "@patternfly/react-core": "3.16.16",
     "patternfly-react": "2.x",
     "prop-types": "15.x",
     "react": "16.6.x",
@@ -59,8 +59,8 @@
     "@babel/polyfill": "7.x",
     "@babel/preset-env": "7.x",
     "@babel/preset-react": "7.x",
-    "@patternfly/react-core": "1.43.x",
     "@patternfly/react-charts": "2.x",
+    "@patternfly/react-core": "3.16.16",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.x",
     "babel-jest": "24.x",

--- a/sass/components/Status/status.scss
+++ b/sass/components/Status/status.scss
@@ -7,6 +7,6 @@
   margin: 0;
 }
 
-.kubevirt-status__span {
+.kubevirt-status__popover {
   cursor: pointer;
 }

--- a/sass/components/Status/status.scss
+++ b/sass/components/Status/status.scss
@@ -6,3 +6,7 @@
   padding: 0;
   margin: 0;
 }
+
+.kubevirt-status__span {
+  cursor: pointer;
+}

--- a/src/components/BareMetalHosts/StatusComponents.js
+++ b/src/components/BareMetalHosts/StatusComponents.js
@@ -28,7 +28,7 @@ GenericSuccess.defaultProps = GenericStatus.defaultProps;
 export const GenericError = ({ status, text, errorMessage }) =>
   errorMessage ? (
     <OverlayStatus icon="error-circle-o" header={<div>{text}</div>}>
-      {<div>{errorMessage}</div>}
+      <div>{errorMessage}</div>
     </OverlayStatus>
   ) : (
     <Status icon="error-circle-o">{text}</Status>
@@ -47,7 +47,7 @@ GenericProgress.defaultProps = GenericStatus.defaultProps;
 // (TODO) Add details for validation errors in Popover component
 export const ValidationError = ({ status, text, errorMessage }) => (
   <OverlayStatus icon="error-circle-o" header={<div>{text}</div>}>
-    {<div>{errorMessage}</div>}
+    <div>{errorMessage}</div>
   </OverlayStatus>
 );
 

--- a/src/components/BareMetalHosts/StatusComponents.js
+++ b/src/components/BareMetalHosts/StatusComponents.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Popover } from '@patternfly/react-core';
 
 import { Status, OverlayStatus } from '../Status';
 
@@ -23,26 +22,14 @@ export const GenericSuccess = ({ status, text, errorMessage }) => <Status icon="
 GenericSuccess.propTypes = GenericStatus.propTypes;
 GenericSuccess.defaultProps = GenericStatus.defaultProps;
 
-const ErrorOverlay = ({ errorMessage }) => (
-  <Popover position="right" size="regular" title="Errors">
-    <div>{errorMessage}</div>
-  </Popover>
-);
-
-ErrorOverlay.propTypes = {
-  errorMessage: PropTypes.string,
-};
-
-ErrorOverlay.defaultProps = {
-  errorMessage: null,
-};
-
 // Generic error status component
 // If the errorMessage property isn't empty its contents are
 // shown in a Popover.
 export const GenericError = ({ status, text, errorMessage }) =>
   errorMessage ? (
-    <OverlayStatus icon="error-circle-o" text={text} overlay={<ErrorOverlay errorMessage={errorMessage} />} />
+    <OverlayStatus icon="error-circle-o" header={<div>{text}</div>}>
+      {<div>{errorMessage}</div>}
+    </OverlayStatus>
   ) : (
     <Status icon="error-circle-o">{text}</Status>
   );
@@ -59,7 +46,9 @@ GenericProgress.defaultProps = GenericStatus.defaultProps;
 // Validation Error component
 // (TODO) Add details for validation errors in Popover component
 export const ValidationError = ({ status, text, errorMessage }) => (
-  <OverlayStatus icon="error-circle-o" text={text} overlay={<ErrorOverlay errorMessage={errorMessage} />} />
+  <OverlayStatus icon="error-circle-o" header={<div>{text}</div>}>
+    {<div>{errorMessage}</div>}
+  </OverlayStatus>
 );
 
 ValidationError.propTypes = {

--- a/src/components/BareMetalHosts/StatusComponents.js
+++ b/src/components/BareMetalHosts/StatusComponents.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Status, OverlayStatus } from '../Status';
+import { Status, PopoverStatus } from '../Status';
 
 // Generic status component as a fallback
 export const GenericStatus = ({ status, text, errorMessage }) => text;
@@ -27,9 +27,9 @@ GenericSuccess.defaultProps = GenericStatus.defaultProps;
 // shown in a Popover.
 export const GenericError = ({ status, text, errorMessage }) =>
   errorMessage ? (
-    <OverlayStatus icon="error-circle-o" header={<div>{text}</div>}>
+    <PopoverStatus icon="error-circle-o" header={<div>{text}</div>}>
       <div>{errorMessage}</div>
-    </OverlayStatus>
+    </PopoverStatus>
   ) : (
     <Status icon="error-circle-o">{text}</Status>
   );
@@ -46,9 +46,9 @@ GenericProgress.defaultProps = GenericStatus.defaultProps;
 // Validation Error component
 // (TODO) Add details for validation errors in Popover component
 export const ValidationError = ({ status, text, errorMessage }) => (
-  <OverlayStatus icon="error-circle-o" header={<div>{text}</div>}>
+  <PopoverStatus icon="error-circle-o" header={<div>{text}</div>}>
     <div>{errorMessage}</div>
-  </OverlayStatus>
+  </PopoverStatus>
 );
 
 ValidationError.propTypes = {

--- a/src/components/BareMetalHosts/tests/__snapshots__/StatusComponents.test.js.snap
+++ b/src/components/BareMetalHosts/tests/__snapshots__/StatusComponents.test.js.snap
@@ -19,7 +19,7 @@ exports[`<GenericError /> renders an error message 1`] = `
 `;
 
 exports[`<GenericError /> with details renders an error message with details 1`] = `
-<OverlayStatus
+<PopoverStatus
   header={
     <div>
       Registration Error
@@ -30,7 +30,7 @@ exports[`<GenericError /> with details renders an error message with details 1`]
   <div>
     some error details
   </div>
-</OverlayStatus>
+</PopoverStatus>
 `;
 
 exports[`<GenericProgress /> renders a progress message 1`] = `
@@ -52,7 +52,7 @@ exports[`<GenericSuccess /> renders a success message 1`] = `
 `;
 
 exports[`<ValidationError /> renders a validation error 1`] = `
-<OverlayStatus
+<PopoverStatus
   header={
     <div>
       Validation Error(s)
@@ -63,5 +63,5 @@ exports[`<ValidationError /> renders a validation error 1`] = `
   <div>
     some validation errors
   </div>
-</OverlayStatus>
+</PopoverStatus>
 `;

--- a/src/components/BareMetalHosts/tests/__snapshots__/StatusComponents.test.js.snap
+++ b/src/components/BareMetalHosts/tests/__snapshots__/StatusComponents.test.js.snap
@@ -20,14 +20,17 @@ exports[`<GenericError /> renders an error message 1`] = `
 
 exports[`<GenericError /> with details renders an error message with details 1`] = `
 <OverlayStatus
-  icon="error-circle-o"
-  overlay={
-    <ErrorOverlay
-      errorMessage="some error details"
-    />
+  header={
+    <div>
+      Registration Error
+    </div>
   }
-  text="Registration Error"
-/>
+  icon="error-circle-o"
+>
+  <div>
+    some error details
+  </div>
+</OverlayStatus>
 `;
 
 exports[`<GenericProgress /> renders a progress message 1`] = `
@@ -50,12 +53,15 @@ exports[`<GenericSuccess /> renders a success message 1`] = `
 
 exports[`<ValidationError /> renders a validation error 1`] = `
 <OverlayStatus
-  icon="error-circle-o"
-  overlay={
-    <ErrorOverlay
-      errorMessage="some validation errors"
-    />
+  header={
+    <div>
+      Validation Error(s)
+    </div>
   }
-  text="Validation Error(s)"
-/>
+  icon="error-circle-o"
+>
+  <div>
+    some validation errors
+  </div>
+</OverlayStatus>
 `;

--- a/src/components/ClusterOverview/Capacity/tests/__snapshots__/Capacity.test.js.snap
+++ b/src/components/ClusterOverview/Capacity/tests/__snapshots__/Capacity.test.js.snap
@@ -162,7 +162,7 @@ exports[`<Capacity /> renders correctly with Provider 1`] = `
                 d="M1.0378342131579386,-87.99387990164998A88,88,0,0,1,1.0378342131579386,87.99387990164998L1.0378342131579519,79.99326784265035A80,80,0,0,0,1.0378342131579519,-79.99326784265035Z"
                 role="presentation"
                 shape-rendering="auto"
-                style="fill:#007bba;padding:8px;stroke:transparent;stroke-width:1"
+                style="fill:#06c;padding:8px;stroke:transparent;stroke-width:1"
                 transform="translate(100, 100)"
               />
               <path
@@ -233,7 +233,7 @@ exports[`<Capacity /> renders correctly with Provider 1`] = `
                 d="M1.0378342131579386,-87.99387990164998A88,88,0,0,1,16.888067747731125,-86.36430493987689L15.260176232599017,-78.53105768643397A80,80,0,0,0,1.0378342131579519,-79.99326784265035Z"
                 role="presentation"
                 shape-rendering="auto"
-                style="fill:#007bba;padding:8px;stroke:transparent;stroke-width:1"
+                style="fill:#06c;padding:8px;stroke:transparent;stroke-width:1"
                 transform="translate(100, 100)"
               />
               <path
@@ -304,7 +304,7 @@ exports[`<Capacity /> renders correctly with Provider 1`] = `
                 d="M1.0378342131579386,-87.99387990164998A88,88,0,0,1,1.0378342131579386,87.99387990164998L1.0378342131579519,79.99326784265035A80,80,0,0,0,1.0378342131579519,-79.99326784265035Z"
                 role="presentation"
                 shape-rendering="auto"
-                style="fill:#007bba;padding:8px;stroke:transparent;stroke-width:1"
+                style="fill:#06c;padding:8px;stroke:transparent;stroke-width:1"
                 transform="translate(100, 100)"
               />
               <path
@@ -375,7 +375,7 @@ exports[`<Capacity /> renders correctly with Provider 1`] = `
                 d="M1.0378342131579386,-87.99387990164998A88,88,0,0,1,1.0378342131579386,87.99387990164998L1.0378342131579519,79.99326784265035A80,80,0,0,0,1.0378342131579519,-79.99326784265035Z"
                 role="presentation"
                 shape-rendering="auto"
-                style="fill:#007bba;padding:8px;stroke:transparent;stroke-width:1"
+                style="fill:#06c;padding:8px;stroke:transparent;stroke-width:1"
                 transform="translate(100, 100)"
               />
               <path

--- a/src/components/ClusterOverview/Utilization/tests/__snapshots__/Utilization.test.js.snap
+++ b/src/components/ClusterOverview/Utilization/tests/__snapshots__/Utilization.test.js.snap
@@ -242,7 +242,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                       d="M40,55L105,51.46116504854369L170,49.69174757281554L235,19.611650485436897L300,37.30582524271845"
                       role="presentation"
                       shape-rendering="auto"
-                      style="fill:none;fill-opacity:0.4;stroke:#39a5dc;stroke-width:2"
+                      style="fill:none;fill-opacity:0.4;stroke:#73bcf7;stroke-width:2"
                     />
                   </g>
                 </g>
@@ -291,7 +291,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -331,7 +331,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -371,7 +371,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -460,7 +460,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                       d="M40,53.820388349514566L105,52.050970873786405L170,46.15291262135922L235,49.101941747572816L300,37.30582524271844"
                       role="presentation"
                       shape-rendering="auto"
-                      style="fill:none;fill-opacity:0.4;stroke:#39a5dc;stroke-width:2"
+                      style="fill:none;fill-opacity:0.4;stroke:#73bcf7;stroke-width:2"
                     />
                   </g>
                 </g>
@@ -509,7 +509,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -549,7 +549,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -589,7 +589,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -707,7 +707,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                       d="M40,51.46116504854369L105,44.383495145631066L170,40.84466019417476L235,26.689320388349515L300,37.30582524271845"
                       role="presentation"
                       shape-rendering="auto"
-                      style="fill:none;fill-opacity:0.4;stroke:#39a5dc;stroke-width:2"
+                      style="fill:none;fill-opacity:0.4;stroke:#73bcf7;stroke-width:2"
                     />
                   </g>
                 </g>
@@ -756,7 +756,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -796,7 +796,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -836,7 +836,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >

--- a/src/components/Dashboard/Capacity/tests/__snapshots__/CapacityItem.test.js.snap
+++ b/src/components/Dashboard/Capacity/tests/__snapshots__/CapacityItem.test.js.snap
@@ -52,9 +52,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
           Object {
             "area": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -63,11 +63,11 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                 "data": Object {
                   "fill": "#bee1f4",
                   "fillOpacity": 0.4,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -80,9 +80,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             },
             "axis": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -96,7 +96,7 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                   "strokeWidth": 1,
                 },
                 "axisLabel": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -110,7 +110,7 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                   "stroke": "none",
                 },
                 "tickLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -128,9 +128,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             "bar": Object {
               "barWidth": 10,
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -140,7 +140,7 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                   "stroke": "none",
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -153,9 +153,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             "boxplot": Object {
               "boxWidth": 20,
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -163,11 +163,11 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
               "style": Object {
                 "max": Object {
                   "padding": 8,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "maxLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -176,11 +176,11 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                 },
                 "median": Object {
                   "padding": 8,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "medianLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -189,11 +189,11 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                 },
                 "min": Object {
                   "padding": 8,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "minLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -205,7 +205,7 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                   "padding": 8,
                 },
                 "q1Labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -217,7 +217,7 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                   "padding": 8,
                 },
                 "q3Labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -229,24 +229,24 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             },
             "candlestick": Object {
               "candleColors": Object {
-                "negative": "#39a5dc",
+                "negative": "#73bcf7",
                 "positive": "#bee1f4",
               },
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
               "padding": 8,
               "style": Object {
                 "data": Object {
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -259,9 +259,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             },
             "chart": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -276,9 +276,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             "errorbar": Object {
               "borderWidth": 8,
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -286,11 +286,11 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -303,9 +303,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             },
             "group": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -314,9 +314,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             },
             "legend": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "gutter": 20,
@@ -326,7 +326,7 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                   "type": "square",
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -334,7 +334,7 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                   "stroke": "transparent",
                 },
                 "title": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -346,9 +346,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             },
             "line": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -356,11 +356,11 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -373,9 +373,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             },
             "pie": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "padding": 20,
@@ -386,7 +386,7 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -397,9 +397,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             },
             "scatter": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -411,7 +411,7 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -424,9 +424,9 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
             },
             "stack": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -445,7 +445,7 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                 "cornerRadius": 0,
                 "fill": "#fff",
                 "pointerEvents": "none",
-                "stroke": "#282d33",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "pointerLength": 10,
@@ -456,15 +456,15 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#282d33",
+                "stroke": "#151515",
                 "textAnchor": "middle",
               },
             },
             "voronoi": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -481,7 +481,7 @@ exports[`<CapacityItem /> renders Capacity Item correctly 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -576,9 +576,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
           Object {
             "area": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -587,11 +587,11 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                 "data": Object {
                   "fill": "#bee1f4",
                   "fillOpacity": 0.4,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -604,9 +604,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             },
             "axis": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -620,7 +620,7 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                   "strokeWidth": 1,
                 },
                 "axisLabel": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -634,7 +634,7 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                   "stroke": "none",
                 },
                 "tickLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -652,9 +652,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             "bar": Object {
               "barWidth": 10,
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -664,7 +664,7 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                   "stroke": "none",
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -677,9 +677,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             "boxplot": Object {
               "boxWidth": 20,
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -687,11 +687,11 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
               "style": Object {
                 "max": Object {
                   "padding": 8,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "maxLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -700,11 +700,11 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                 },
                 "median": Object {
                   "padding": 8,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "medianLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -713,11 +713,11 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                 },
                 "min": Object {
                   "padding": 8,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "minLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -729,7 +729,7 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                   "padding": 8,
                 },
                 "q1Labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -741,7 +741,7 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                   "padding": 8,
                 },
                 "q3Labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -753,24 +753,24 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             },
             "candlestick": Object {
               "candleColors": Object {
-                "negative": "#39a5dc",
+                "negative": "#73bcf7",
                 "positive": "#bee1f4",
               },
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
               "padding": 8,
               "style": Object {
                 "data": Object {
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -783,9 +783,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             },
             "chart": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -800,9 +800,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             "errorbar": Object {
               "borderWidth": 8,
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -810,11 +810,11 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -827,9 +827,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             },
             "group": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -838,9 +838,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             },
             "legend": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "gutter": 20,
@@ -850,7 +850,7 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                   "type": "square",
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -858,7 +858,7 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                   "stroke": "transparent",
                 },
                 "title": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -870,9 +870,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             },
             "line": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -880,11 +880,11 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -897,9 +897,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             },
             "pie": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "padding": 20,
@@ -910,7 +910,7 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -921,9 +921,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             },
             "scatter": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -935,7 +935,7 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -948,9 +948,9 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
             },
             "stack": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -969,7 +969,7 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                 "cornerRadius": 0,
                 "fill": "#fff",
                 "pointerEvents": "none",
-                "stroke": "#282d33",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "pointerLength": 10,
@@ -980,15 +980,15 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#282d33",
+                "stroke": "#151515",
                 "textAnchor": "middle",
               },
             },
             "voronoi": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1005,7 +1005,7 @@ exports[`<CapacityItem /> renders Loading capacity item correctly 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1098,9 +1098,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
           Object {
             "area": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1109,11 +1109,11 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                 "data": Object {
                   "fill": "#bee1f4",
                   "fillOpacity": 0.4,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1126,9 +1126,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             },
             "axis": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1142,7 +1142,7 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                   "strokeWidth": 1,
                 },
                 "axisLabel": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1156,7 +1156,7 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                   "stroke": "none",
                 },
                 "tickLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1174,9 +1174,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             "bar": Object {
               "barWidth": 10,
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1186,7 +1186,7 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                   "stroke": "none",
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1199,9 +1199,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             "boxplot": Object {
               "boxWidth": 20,
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1209,11 +1209,11 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
               "style": Object {
                 "max": Object {
                   "padding": 8,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "maxLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1222,11 +1222,11 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                 },
                 "median": Object {
                   "padding": 8,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "medianLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1235,11 +1235,11 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                 },
                 "min": Object {
                   "padding": 8,
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "minLabels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1251,7 +1251,7 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                   "padding": 8,
                 },
                 "q1Labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1263,7 +1263,7 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                   "padding": 8,
                 },
                 "q3Labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1275,24 +1275,24 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             },
             "candlestick": Object {
               "candleColors": Object {
-                "negative": "#39a5dc",
+                "negative": "#73bcf7",
                 "positive": "#bee1f4",
               },
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
               "padding": 8,
               "style": Object {
                 "data": Object {
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1305,9 +1305,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             },
             "chart": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1322,9 +1322,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             "errorbar": Object {
               "borderWidth": 8,
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1332,11 +1332,11 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1349,9 +1349,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             },
             "group": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1360,9 +1360,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             },
             "legend": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "gutter": 20,
@@ -1372,7 +1372,7 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                   "type": "square",
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1380,7 +1380,7 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                   "stroke": "transparent",
                 },
                 "title": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1392,9 +1392,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             },
             "line": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1402,11 +1402,11 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
-                  "stroke": "#39a5dc",
+                  "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1419,9 +1419,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             },
             "pie": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "padding": 20,
@@ -1432,7 +1432,7 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1443,9 +1443,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             },
             "scatter": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1457,7 +1457,7 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1470,9 +1470,9 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
             },
             "stack": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1491,7 +1491,7 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                 "cornerRadius": 0,
                 "fill": "#fff",
                 "pointerEvents": "none",
-                "stroke": "#282d33",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "pointerLength": 10,
@@ -1502,15 +1502,15 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#282d33",
+                "stroke": "#151515",
                 "textAnchor": "middle",
               },
             },
             "voronoi": Object {
               "colorScale": Array [
-                "#007bba",
+                "#06c",
                 "#bee1f4",
-                "#39a5dc",
+                "#73bcf7",
                 "#0066ff",
               ],
               "height": 301,
@@ -1527,7 +1527,7 @@ exports[`<CapacityItem /> renders Unknown capacity item correctly 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#282d33",
+                  "fill": "#151515",
                   "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
                   "fontSize": 14,
                   "letterSpacing": "normal",

--- a/src/components/Dashboard/Utilization/tests/__snapshots__/UtilizationBody.test.js.snap
+++ b/src/components/Dashboard/Utilization/tests/__snapshots__/UtilizationBody.test.js.snap
@@ -69,7 +69,7 @@ exports[`<UtilizationBody /> renders correctly 1`] = `
                   d="M40,51.46116504854369L105,55L170,49.69174757281554L235,19.611650485436897L300,53.230582524271846"
                   role="presentation"
                   shape-rendering="auto"
-                  style="fill:none;fill-opacity:0.4;stroke:#39a5dc;stroke-width:2"
+                  style="fill:none;fill-opacity:0.4;stroke:#73bcf7;stroke-width:2"
                 />
               </g>
             </g>
@@ -118,7 +118,7 @@ exports[`<UtilizationBody /> renders correctly 1`] = `
                 >
                   <tspan
                     dx="0"
-                    style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                    style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                     text-anchor="end"
                     x="29"
                   >

--- a/src/components/Dashboard/Utilization/tests/__snapshots__/UtilizationItem.test.js.snap
+++ b/src/components/Dashboard/Utilization/tests/__snapshots__/UtilizationItem.test.js.snap
@@ -66,7 +66,7 @@ exports[`<UtilizationItem /> renders correctly 1`] = `
                 d="M40,51.46116504854369L105,55L170,49.69174757281554L235,19.611650485436897L300,53.230582524271846"
                 role="presentation"
                 shape-rendering="auto"
-                style="fill:none;fill-opacity:0.4;stroke:#39a5dc;stroke-width:2"
+                style="fill:none;fill-opacity:0.4;stroke:#73bcf7;stroke-width:2"
               />
             </g>
           </g>
@@ -115,7 +115,7 @@ exports[`<UtilizationItem /> renders correctly 1`] = `
               >
                 <tspan
                   dx="0"
-                  style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                  style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                   text-anchor="end"
                   x="29"
                 >
@@ -231,7 +231,7 @@ exports[`<UtilizationItem /> renders correctly 2`] = `
                 d="M40,51.46116504854369L105,55L170,49.69174757281554L235,19.611650485436897L300,53.230582524271846"
                 role="presentation"
                 shape-rendering="auto"
-                style="fill:none;fill-opacity:0.4;stroke:#39a5dc;stroke-width:2"
+                style="fill:none;fill-opacity:0.4;stroke:#73bcf7;stroke-width:2"
               />
             </g>
           </g>
@@ -280,7 +280,7 @@ exports[`<UtilizationItem /> renders correctly 2`] = `
               >
                 <tspan
                   dx="0"
-                  style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                  style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                   text-anchor="end"
                   x="29"
                 >
@@ -320,7 +320,7 @@ exports[`<UtilizationItem /> renders correctly 2`] = `
               >
                 <tspan
                   dx="0"
-                  style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                  style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                   text-anchor="end"
                   x="29"
                 >
@@ -360,7 +360,7 @@ exports[`<UtilizationItem /> renders correctly 2`] = `
               >
                 <tspan
                   dx="0"
-                  style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                  style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                   text-anchor="end"
                   x="29"
                 >

--- a/src/components/NodeStatus/NodeStatus.js
+++ b/src/components/NodeStatus/NodeStatus.js
@@ -14,7 +14,7 @@ const UnderMaintenanceStatus = ({ node, maintenance, TimestampComponent }) => {
   const maintenanceReason = getMaintenanceReason(maintenance);
   const created = getCreationTimestamp(maintenance);
   const overlay = (
-    <Popover id={`${getName(node)}-status-popover`} title="Under maintenance">
+    <React.Fragment>
       <div className="kubevirt-host-status__description">This host is under maintenance.</div>
       {maintenanceReason && (
         <React.Fragment>
@@ -25,10 +25,14 @@ const UnderMaintenanceStatus = ({ node, maintenance, TimestampComponent }) => {
       <div>
         Started: <TimestampComponent simple timestamp={created} />
       </div>
-    </Popover>
+    </React.Fragment>
   );
 
-  return <OverlayStatus icon="off" overlay={overlay} text="Under maintenance" />;
+  return (
+    <OverlayStatus icon="off" header="Under maintenance">
+      {overlay}
+    </OverlayStatus>
+  );
 };
 
 UnderMaintenanceStatus.defaultProps = {
@@ -45,7 +49,7 @@ const StoppingMaintenanceStatus = ({ node, maintenance, TimestampComponent }) =>
   const created = getCreationTimestamp(maintenance);
   const deleted = getDeletionTimestamp(maintenance);
   const overlay = (
-    <Popover id={`${getName(node)}-status-popover`} title="Stopping maintenance">
+    <React.Fragment>
       <div className="kubevirt-host-status__description">
         This host is leaving maintenance. It will rejoin the cluster and resume accepting workloads.
       </div>
@@ -55,10 +59,14 @@ const StoppingMaintenanceStatus = ({ node, maintenance, TimestampComponent }) =>
       <div>
         Ended: <TimestampComponent simple timestamp={deleted} />
       </div>
-    </Popover>
+    </React.Fragment>
   );
 
-  return <OverlayStatus icon="off" overlay={overlay} text="Stopping maintenance" />;
+  return (
+    <OverlayStatus icon="off" header="Stopping maintenance">
+      {overlay}
+    </OverlayStatus>
+  );
 };
 
 StoppingMaintenanceStatus.defaultProps = {

--- a/src/components/NodeStatus/NodeStatus.js
+++ b/src/components/NodeStatus/NodeStatus.js
@@ -7,14 +7,14 @@ import {
   NODE_STATUS_STOPPING_MAINTENANCE,
 } from '../../utils/status/node';
 import { getCreationTimestamp, getDeletionTimestamp, getMaintenanceReason } from '../../selectors';
-import { OverlayStatus } from '../Status';
+import { PopoverStatus } from '../Status';
 
 const UnderMaintenanceStatus = ({ node, maintenance, TimestampComponent }) => {
   const maintenanceReason = getMaintenanceReason(maintenance);
   const created = getCreationTimestamp(maintenance);
 
   return (
-    <OverlayStatus icon="off" header="Under maintenance">
+    <PopoverStatus icon="off" header="Under maintenance">
       <div className="kubevirt-host-status__description">This host is under maintenance.</div>
       {maintenanceReason && (
         <React.Fragment>
@@ -25,7 +25,7 @@ const UnderMaintenanceStatus = ({ node, maintenance, TimestampComponent }) => {
       <div>
         Started: <TimestampComponent simple timestamp={created} />
       </div>
-    </OverlayStatus>
+    </PopoverStatus>
   );
 };
 
@@ -44,7 +44,7 @@ const StoppingMaintenanceStatus = ({ node, maintenance, TimestampComponent }) =>
   const deleted = getDeletionTimestamp(maintenance);
 
   return (
-    <OverlayStatus icon="off" header="Stopping maintenance">
+    <PopoverStatus icon="off" header="Stopping maintenance">
       <div className="kubevirt-host-status__description">
         This host is leaving maintenance. It will rejoin the cluster and resume accepting workloads.
       </div>
@@ -54,7 +54,7 @@ const StoppingMaintenanceStatus = ({ node, maintenance, TimestampComponent }) =>
       <div>
         Ended: <TimestampComponent simple timestamp={deleted} />
       </div>
-    </OverlayStatus>
+    </PopoverStatus>
   );
 };
 

--- a/src/components/NodeStatus/NodeStatus.js
+++ b/src/components/NodeStatus/NodeStatus.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Popover } from 'patternfly-react';
 import PropTypes from 'prop-types';
 
 import {
@@ -7,7 +6,7 @@ import {
   NODE_STATUS_UNDER_MAINTENANCE,
   NODE_STATUS_STOPPING_MAINTENANCE,
 } from '../../utils/status/node';
-import { getCreationTimestamp, getDeletionTimestamp, getName, getMaintenanceReason } from '../../selectors';
+import { getCreationTimestamp, getDeletionTimestamp, getMaintenanceReason } from '../../selectors';
 import { OverlayStatus } from '../Status';
 
 const UnderMaintenanceStatus = ({ node, maintenance, TimestampComponent }) => {

--- a/src/components/NodeStatus/NodeStatus.js
+++ b/src/components/NodeStatus/NodeStatus.js
@@ -12,8 +12,9 @@ import { OverlayStatus } from '../Status';
 const UnderMaintenanceStatus = ({ node, maintenance, TimestampComponent }) => {
   const maintenanceReason = getMaintenanceReason(maintenance);
   const created = getCreationTimestamp(maintenance);
-  const overlay = (
-    <React.Fragment>
+
+  return (
+    <OverlayStatus icon="off" header="Under maintenance">
       <div className="kubevirt-host-status__description">This host is under maintenance.</div>
       {maintenanceReason && (
         <React.Fragment>
@@ -24,12 +25,6 @@ const UnderMaintenanceStatus = ({ node, maintenance, TimestampComponent }) => {
       <div>
         Started: <TimestampComponent simple timestamp={created} />
       </div>
-    </React.Fragment>
-  );
-
-  return (
-    <OverlayStatus icon="off" header="Under maintenance">
-      {overlay}
     </OverlayStatus>
   );
 };
@@ -47,8 +42,9 @@ UnderMaintenanceStatus.propTypes = {
 const StoppingMaintenanceStatus = ({ node, maintenance, TimestampComponent }) => {
   const created = getCreationTimestamp(maintenance);
   const deleted = getDeletionTimestamp(maintenance);
-  const overlay = (
-    <React.Fragment>
+
+  return (
+    <OverlayStatus icon="off" header="Stopping maintenance">
       <div className="kubevirt-host-status__description">
         This host is leaving maintenance. It will rejoin the cluster and resume accepting workloads.
       </div>
@@ -58,12 +54,6 @@ const StoppingMaintenanceStatus = ({ node, maintenance, TimestampComponent }) =>
       <div>
         Ended: <TimestampComponent simple timestamp={deleted} />
       </div>
-    </React.Fragment>
-  );
-
-  return (
-    <OverlayStatus icon="off" header="Stopping maintenance">
-      {overlay}
     </OverlayStatus>
   );
 };

--- a/src/components/Status/Status.js
+++ b/src/components/Status/Status.js
@@ -22,7 +22,7 @@ Status.propTypes = {
 
 export const PopoverStatus = ({ icon, header, children }) => (
   <Popover position="right" headerContent={header} bodyContent={children}>
-    <span>
+    <span className="kubevirt-status__span">
       <Status icon={icon}>
         <Button className="kubevirt-status__button" bsStyle="link">
           {header}

--- a/src/components/Status/Status.js
+++ b/src/components/Status/Status.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Icon, OverlayTrigger, Button } from 'patternfly-react';
+import { Popover } from '@patternfly/react-core';
+import { Icon, Button } from 'patternfly-react';
 import PropTypes from 'prop-types';
 
 export const Status = ({ icon, children }) => (
@@ -19,14 +20,16 @@ Status.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
 };
 
-export const OverlayStatus = ({ icon, text, overlay }) => (
-  <Status icon={icon}>
-    <OverlayTrigger overlay={overlay} placement="right" trigger={['click']} rootClose>
-      <Button className="kubevirt-status__button" bsStyle="link">
-        {text}
-      </Button>
-    </OverlayTrigger>
-  </Status>
+export const OverlayStatus = ({ icon, header, children }) => (
+  <Popover position="right" headerContent={header} bodyContent={children}>
+    <span>
+      <Status icon={icon}>
+        <Button className="kubevirt-status__button" bsStyle="link">
+          {header}
+        </Button>
+      </Status>
+    </span>
+  </Popover>
 );
 
 OverlayStatus.defaultProps = {
@@ -35,8 +38,8 @@ OverlayStatus.defaultProps = {
 
 OverlayStatus.propTypes = {
   icon: PropTypes.string,
-  text: PropTypes.string.isRequired,
-  overlay: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+  header: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
 };
 
 export const LinkStatus = ({ icon, children, linkMessage, linkTo }) =>

--- a/src/components/Status/Status.js
+++ b/src/components/Status/Status.js
@@ -20,7 +20,7 @@ Status.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
 };
 
-export const OverlayStatus = ({ icon, header, children }) => (
+export const PopoverStatus = ({ icon, header, children }) => (
   <Popover position="right" headerContent={header} bodyContent={children}>
     <span>
       <Status icon={icon}>
@@ -32,11 +32,11 @@ export const OverlayStatus = ({ icon, header, children }) => (
   </Popover>
 );
 
-OverlayStatus.defaultProps = {
+PopoverStatus.defaultProps = {
   icon: null,
 };
 
-OverlayStatus.propTypes = {
+PopoverStatus.propTypes = {
   icon: PropTypes.string,
   header: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,

--- a/src/components/Status/Status.js
+++ b/src/components/Status/Status.js
@@ -22,7 +22,7 @@ Status.propTypes = {
 
 export const PopoverStatus = ({ icon, header, children }) => (
   <Popover position="right" headerContent={header} bodyContent={children}>
-    <span className="kubevirt-status__span">
+    <span className="kubevirt-status__popover">
       <Status icon={icon}>
         <Button className="kubevirt-status__button" bsStyle="link">
           {header}

--- a/src/components/Status/fixtures/Status.fixture.js
+++ b/src/components/Status/fixtures/Status.fixture.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Status, OverlayStatus } from '../Status';
+import { Status, PopoverStatus } from '../Status';
 
 export default [
   {
@@ -12,7 +12,7 @@ export default [
     },
   },
   {
-    component: OverlayStatus,
+    component: PopoverStatus,
     name: 'Status with overlay',
     props: {
       icon: 'off',

--- a/src/components/Status/fixtures/Status.fixture.js
+++ b/src/components/Status/fixtures/Status.fixture.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Popover } from 'patternfly-react';
 
 import { Status, OverlayStatus } from '../Status';
 
@@ -17,12 +16,8 @@ export default [
     name: 'Status with overlay',
     props: {
       icon: 'off',
-      text: 'status text',
-      overlay: (
-        <Popover id="status-popover" title="popover">
-          <div>some content</div>
-        </Popover>
-      ),
+      header: 'status text',
+      children: <div>some content</div>,
     },
   },
 ];

--- a/src/components/StorageOverview/Capacity/tests/__snapshots__/Capacity.test.js.snap
+++ b/src/components/StorageOverview/Capacity/tests/__snapshots__/Capacity.test.js.snap
@@ -108,7 +108,7 @@ exports[`<Capacity /> renders correctly with Provider 1`] = `
                 d="M1.0378342131579386,-87.99387990164998A88,88,0,0,1,25.653005755549977,84.17792641604876L23.41115576348232,76.49782863466105A80,80,0,0,0,1.0378342131579519,-79.99326784265035Z"
                 role="presentation"
                 shape-rendering="auto"
-                style="fill:#007bba;padding:8px;stroke:transparent;stroke-width:1"
+                style="fill:#06c;padding:8px;stroke:transparent;stroke-width:1"
                 transform="translate(100, 100)"
               />
               <path

--- a/src/components/StorageOverview/Utilization/tests/__snapshots__/Utilization.test.js.snap
+++ b/src/components/StorageOverview/Utilization/tests/__snapshots__/Utilization.test.js.snap
@@ -326,7 +326,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
           >
             <tspan
               dx="0"
-              style="font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;font-size:14px;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+              style="font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;font-size:14px;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
               text-anchor="middle"
               x="43"
             >
@@ -366,7 +366,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
           >
             <tspan
               dx="0"
-              style="font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;font-size:14px;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+              style="font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;font-size:14px;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
               text-anchor="middle"
               x="43"
             >
@@ -406,7 +406,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
           >
             <tspan
               dx="0"
-              style="font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;font-size:14px;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+              style="font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;font-size:14px;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
               text-anchor="middle"
               x="43"
             >
@@ -446,7 +446,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
           >
             <tspan
               dx="0"
-              style="font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;font-size:14px;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+              style="font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;font-size:14px;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
               text-anchor="middle"
               x="43"
             >
@@ -486,7 +486,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
           >
             <tspan
               dx="0"
-              style="font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;font-size:14px;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+              style="font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;font-size:14px;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
               text-anchor="middle"
               x="43"
             >
@@ -574,7 +574,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                       d="M40,52.640776699029125L105,49.101941747572816L170,37.30582524271844L235,43.20388349514563L300,19.61165048543689"
                       role="presentation"
                       shape-rendering="auto"
-                      style="fill:none;fill-opacity:0.4;stroke:#39a5dc;stroke-width:2"
+                      style="fill:none;fill-opacity:0.4;stroke:#73bcf7;stroke-width:2"
                     />
                   </g>
                 </g>
@@ -623,7 +623,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -663,7 +663,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -703,7 +703,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -792,7 +792,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                       d="M40,55L105,51.46116504854369L170,49.69174757281554L235,19.611650485436897L300,37.30582524271845"
                       role="presentation"
                       shape-rendering="auto"
-                      style="fill:none;fill-opacity:0.4;stroke:#39a5dc;stroke-width:2"
+                      style="fill:none;fill-opacity:0.4;stroke:#73bcf7;stroke-width:2"
                     />
                   </g>
                 </g>
@@ -841,7 +841,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -881,7 +881,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -921,7 +921,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -1010,7 +1010,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                       d="M40,55L105,51.46116504854369L170,49.69174757281554L235,19.611650485436897L300,37.30582524271845"
                       role="presentation"
                       shape-rendering="auto"
-                      style="fill:none;fill-opacity:0.4;stroke:#39a5dc;stroke-width:2"
+                      style="fill:none;fill-opacity:0.4;stroke:#73bcf7;stroke-width:2"
                     />
                   </g>
                 </g>
@@ -1059,7 +1059,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -1099,7 +1099,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -1139,7 +1139,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -1228,7 +1228,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                       d="M40,52.640776699029125L105,49.101941747572816L170,37.30582524271844L235,43.20388349514563L300,19.61165048543689"
                       role="presentation"
                       shape-rendering="auto"
-                      style="fill:none;fill-opacity:0.4;stroke:#39a5dc;stroke-width:2"
+                      style="fill:none;fill-opacity:0.4;stroke:#73bcf7;stroke-width:2"
                     />
                   </g>
                 </g>
@@ -1277,7 +1277,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -1317,7 +1317,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >
@@ -1357,7 +1357,7 @@ exports[`<Utilization /> renders correctly with Provider 1`] = `
                     >
                       <tspan
                         dx="0"
-                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#282d33;stroke:transparent"
+                        style="font-size:10px;font-family:'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif;letter-spacing:normal;padding:10px;fill:#151515;stroke:transparent"
                         text-anchor="end"
                         x="29"
                       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -862,20 +862,20 @@
     file-saver "^1.3.8"
     xterm "^3.3.0"
 
-"@patternfly/react-core@3.16.16":
-  version "3.16.16"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.16.16.tgz#0d235dabecb5175dcf8dfcc584cf371bf9af48c5"
-  integrity sha512-bF/yEHFFSGY/tH45yuHrzeX98bZpcMCSyHIZoXgQ8z0fMbz4e2MW7RSJaGMo0Mpo6wpjw6RnRS9ZcdhtHFY9Rg==
+"@patternfly/react-core@3.16.x":
+  version "3.16.10"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.16.10.tgz#32b9e29345c9fc8a1b8b1ffbec14196ef7d55dda"
+  integrity sha512-ASoNNuC+S2UjUeT2aR7LsAuDJpvXzMHYCjRc9WmXD9S52nvqA5p4SS9cXV60RCTvRpUbXJ7/55gnxi4Dt9u6/A==
   dependencies:
-    "@patternfly/react-icons" "^3.9.2"
-    "@patternfly/react-styles" "^3.2.1"
-    "@patternfly/react-tokens" "^2.5.2"
+    "@patternfly/react-icons" "^3.8.1"
+    "@patternfly/react-styles" "^3.2.0"
+    "@patternfly/react-tokens" "^2.5.1"
     "@tippy.js/react" "^1.1.1"
     emotion "^9.2.9"
     exenv "^1.2.2"
     focus-trap-react "^4.0.1"
 
-"@patternfly/react-icons@^3.9.2":
+"@patternfly/react-icons@^3.8.1":
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.9.2.tgz#8a4959a6cdf59929e89f2627a2e3a97e4cb5d798"
   integrity sha512-EwPB+Nodd7zwiFh7R3Qq6Dif+xUR3WOwaJ+SRbP5NsxEAJf3CyYyrd7rbN8yFrFLTMKzknT2ez9XrP/5Lgr5LQ==
@@ -900,10 +900,10 @@
     relative "^3.0.2"
     resolve-from "^4.0.0"
 
-"@patternfly/react-styles@^3.2.1":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.2.2.tgz#9c9cc5e2ada4c020a8bf06a137f90711a90a62c8"
-  integrity sha512-PYAeET+h+tEF6BKkaKRderHqg0GyzA4RULrynW8cUKhP4dgbsylScZQm7JPCkEYXFQlzeRFqgFxCfbv/8mg3ig==
+"@patternfly/react-styles@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.2.0.tgz#c3008b472767109ff5127b14da9cad6506c6bf4f"
+  integrity sha512-8M7bo4kPvypHlbzuynV53xjk5176EktfEgZ283sfHmvUlU3Yvq2+m8hS9ERHE9gd91Ip4HiyucAVVACd2gtHNQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0-beta.48"
     camel-case "^3.0.0"
@@ -918,10 +918,10 @@
     relative "^3.0.2"
     resolve-from "^4.0.0"
 
-"@patternfly/react-tokens@^2.5.2":
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.5.2.tgz#268348551b91dc2ad38403ef342892aff0b38b82"
-  integrity sha512-N2J50hVXXlcObHLYc5tXeCWolkZcqa9oDIFFDmdHuJpH4+Sh3sZf1iRtixnN5VdE8+MAKv9p+kkgpuPKkUroMw==
+"@patternfly/react-tokens@^2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.5.1.tgz#f0b1d526ad19999f9ff7cbac733c94a258c714ab"
+  integrity sha512-ZykUfWT4yCELXhGGwQxcNqnXwe3sqfSuoL6IlQRV6wtUKk+/et7NkVvrRwvci926+Usemr4IQVc8V9gbHqRN/A==
 
 "@skidding/linked-list@^1.0.2":
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,6 +685,18 @@
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
 
+"@fortawesome/fontawesome-common-types@^0.2.18":
+  version "0.2.18"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.18.tgz#c0d8f073a5116b2de0a2c8a7aba66093a6956ce7"
+  integrity sha512-834DrzO2Ne3upCW+mJJPC/E6BsFcj+2Z1HmPIhbpbj8UaKmXWum4NClqLpUiMetugRlHuG4jbIHNdv2/lc3c1Q==
+
+"@fortawesome/free-brands-svg-icons@^5.8.1":
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.8.2.tgz#e68a509c986d5d197cc5bd9ae8d966eff513468d"
+  integrity sha512-nhEWctDOP6f+Ka10LXAFoF+6mtWidC2iQgTBGRGgydmhBtcIEwyxWVx5wQHa86A1zAMi5TnipDAYQs2qn7DD6A==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.18"
+
 "@jest/console@^24.3.0":
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.3.0.tgz#7bd920d250988ba0bf1352c4493a48e1cb97671e"
@@ -850,38 +862,25 @@
     file-saver "^1.3.8"
     xterm "^3.3.0"
 
-"@patternfly/react-core@1.43.x":
-  version "1.43.8"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-1.43.8.tgz#7afea38f760360ae337112ac46e628c0d3870313"
+"@patternfly/react-core@3.16.16":
+  version "3.16.16"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-3.16.16.tgz#0d235dabecb5175dcf8dfcc584cf371bf9af48c5"
+  integrity sha512-bF/yEHFFSGY/tH45yuHrzeX98bZpcMCSyHIZoXgQ8z0fMbz4e2MW7RSJaGMo0Mpo6wpjw6RnRS9ZcdhtHFY9Rg==
   dependencies:
-    "@patternfly/react-icons" "^2.9.5"
-    "@patternfly/react-styles" "^2.3.0"
+    "@patternfly/react-icons" "^3.9.2"
+    "@patternfly/react-styles" "^3.2.1"
+    "@patternfly/react-tokens" "^2.5.2"
     "@tippy.js/react" "^1.1.1"
+    emotion "^9.2.9"
     exenv "^1.2.2"
     focus-trap-react "^4.0.1"
-  optionalDependencies:
-    "@patternfly/react-tokens" "^1.0.0"
 
-"@patternfly/react-icons@^2.9.5":
-  version "2.10.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-2.10.6.tgz#496c83e1a54257d3929df58a40e42410af35968d"
-
-"@patternfly/react-styles@^2.3.0":
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-2.3.5.tgz#c5a020de2ca2a66489a195be74adbbf3babf5df9"
+"@patternfly/react-icons@^3.9.2":
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.9.2.tgz#8a4959a6cdf59929e89f2627a2e3a97e4cb5d798"
+  integrity sha512-EwPB+Nodd7zwiFh7R3Qq6Dif+xUR3WOwaJ+SRbP5NsxEAJf3CyYyrd7rbN8yFrFLTMKzknT2ez9XrP/5Lgr5LQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0-beta.48"
-    camel-case "^3.0.0"
-    css "^2.2.3"
-    cssom "^0.3.4"
-    cssstyle "^0.3.1"
-    emotion "^9.2.9"
-    emotion-server "^9.2.9"
-    fbjs-scripts "^0.8.3"
-    fs-extra "^6.0.1"
-    jsdom "^11.11.0"
-    relative "^3.0.2"
-    resolve-from "^4.0.0"
+    "@fortawesome/free-brands-svg-icons" "^5.8.1"
 
 "@patternfly/react-styles@^2.4.1":
   version "2.4.1"
@@ -901,9 +900,28 @@
     relative "^3.0.2"
     resolve-from "^4.0.0"
 
-"@patternfly/react-tokens@^1.0.0":
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-1.10.3.tgz#02e8d06ff6e0a3346b49731e1c481aef9f2e9f43"
+"@patternfly/react-styles@^3.2.1":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.2.2.tgz#9c9cc5e2ada4c020a8bf06a137f90711a90a62c8"
+  integrity sha512-PYAeET+h+tEF6BKkaKRderHqg0GyzA4RULrynW8cUKhP4dgbsylScZQm7JPCkEYXFQlzeRFqgFxCfbv/8mg3ig==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0-beta.48"
+    camel-case "^3.0.0"
+    css "^2.2.3"
+    cssom "^0.3.4"
+    cssstyle "^0.3.1"
+    emotion "^9.2.9"
+    emotion-server "^9.2.9"
+    fbjs-scripts "^0.8.3"
+    fs-extra "^6.0.1"
+    jsdom "^11.11.0"
+    relative "^3.0.2"
+    resolve-from "^4.0.0"
+
+"@patternfly/react-tokens@^2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.5.2.tgz#268348551b91dc2ad38403ef342892aff0b38b82"
+  integrity sha512-N2J50hVXXlcObHLYc5tXeCWolkZcqa9oDIFFDmdHuJpH4+Sh3sZf1iRtixnN5VdE8+MAKv9p+kkgpuPKkUroMw==
 
 "@skidding/linked-list@^1.0.2":
   version "1.0.2"


### PR DESCRIPTION
Currently BareMetalHosts Error status is broken.

-  Fix use of PF4 popover.
-  Syncing with `openshift/console` to patternfly-4 core version `3.16` from `1.43.x`.

Notes:
-  patternfly-4 v `1.x` has a broken `Popover`.
-  web-ui version of pf4 react is currently 2.4.1:
   https://github.com/kubevirt/web-ui/blob/master/frontend/package.json#L63
- openshift console use 3.16.16:
   https://github.com/openshift/console/blob/master/frontend/package.json#L66

Screenshot:
![Screenshot from 2019-05-22 13-30-17](https://user-images.githubusercontent.com/2181522/58167964-d78faf00-7c95-11e9-8211-63e5346ae218.jpg)
