### PR TITLE
Capacity Card Dropdown

### DIFF
--- a/sass/components/Dashboard/capacity.scss
+++ b/sass/components/Dashboard/capacity.scss
@@ -9,7 +9,7 @@
   flex-direction: column;
   text-align: center;
   justify-content: space-between;
-  flex: 0 1 120px;
+  flex: 0 1 150px;
 }
 
 .kubevirt-capacity__item-title {

--- a/src/components/StorageOverview/Capacity/Capacity.js
+++ b/src/components/StorageOverview/Capacity/Capacity.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Row, Col } from 'patternfly-react';
 
 import { InlineLoading } from '../../Loading';
 
@@ -9,30 +10,82 @@ import {
   DashboardCardHeader,
   DashboardCardTitle,
 } from '../../Dashboard/DashboardCard';
+import { Dropdown } from '../../Form/Dropdown';
+import { DashboardCardActionsBody } from '../../Dashboard/DashboardCard/DashboardCardActionsBody';
+
 import { StorageOverviewContext } from '../StorageOverviewContext';
 import { CapacityItem } from '../../Dashboard/Capacity/CapacityItem';
 import { formatBytes } from '../../../utils';
 import { getCapacityStats } from '../../../selectors';
 import { CapacityBody } from '../../Dashboard/Capacity/CapacityBody';
+import { TOTAL, CAPACITY, VMSVSPODS } from './strings';
+
+const capacityTypes = [TOTAL, CAPACITY, VMSVSPODS];
 
 export class Capacity extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      capacity: capacityTypes[0],
+    };
+  }
+
+  convertMetrics = (total, used, title) => ({ total, used, title });
+
+  changeCapacityMetric = newVal => {
+    this.setState({ capacity: newVal }, this.getNewCapacityMetric);
+  };
+
+  getNewCapacityMetric = () => {
+    switch (this.state.capacity) {
+      case TOTAL:
+        return this.convertMetrics(this.props.capacityTotal, this.props.capacityUsed, TOTAL);
+      case CAPACITY:
+        return this.convertMetrics(this.props.capacityRequested, this.props.capacityUsed, CAPACITY);
+      case VMSVSPODS:
+        return this.convertMetrics(this.props.podsCapacity, this.props.vmsCapacity, VMSVSPODS);
+      default:
+        return [];
+    }
+  };
+
   render() {
-    const { capacityTotal, capacityUsed, LoadingComponent } = this.props;
+    const { capacityTotal, capacityRequested, capacityUsed, vmsCapacity, podsCapacity, LoadingComponent } = this.props;
+
+    const capacitymetric = this.getNewCapacityMetric();
+    const isLoading = !capacityTotal && !capacityRequested && !capacityUsed && !vmsCapacity && !podsCapacity;
+
     return (
       <DashboardCard className="kubevirt-capacity__card">
         <DashboardCardHeader>
-          <DashboardCardTitle>Capacity</DashboardCardTitle>
+          <Row>
+            <Col lg={6} md={6} sm={6} xs={6}>
+              <DashboardCardTitle>Capacity</DashboardCardTitle>
+            </Col>
+            <Col>
+              <DashboardCardActionsBody>
+                <Dropdown
+                  id="capacity-type"
+                  value={this.state.capacity}
+                  onChange={this.changeCapacityMetric}
+                  choices={capacityTypes}
+                  disabled={isLoading}
+                  groupClassName="kubevirt-dropdown__group"
+                />
+              </DashboardCardActionsBody>
+            </Col>
+          </Row>
         </DashboardCardHeader>
         <DashboardCardBody>
           <CapacityBody>
             <CapacityItem
               id="capacity"
-              title="Total capacity"
-              used={getCapacityStats(capacityUsed)}
-              total={getCapacityStats(capacityTotal)}
+              title={capacitymetric.title}
+              used={getCapacityStats(capacitymetric.used)}
+              total={getCapacityStats(capacitymetric.total)}
               formatValue={formatBytes}
+              isLoading={!(capacitymetric.used && capacitymetric.total)}
               LoadingComponent={LoadingComponent}
-              isLoading={!(capacityUsed && capacityTotal)}
             />
           </CapacityBody>
         </DashboardCardBody>
@@ -43,13 +96,19 @@ export class Capacity extends React.PureComponent {
 
 Capacity.defaultProps = {
   capacityTotal: null,
+  capacityRequested: null,
   capacityUsed: null,
+  vmsCapacity: null,
+  podsCapacity: null,
   LoadingComponent: InlineLoading,
 };
 
 Capacity.propTypes = {
   capacityTotal: PropTypes.object,
+  capacityRequested: PropTypes.object,
   capacityUsed: PropTypes.object,
+  vmsCapacity: PropTypes.object,
+  podsCapacity: PropTypes.object,
   LoadingComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
 };
 
@@ -59,6 +118,9 @@ export const CapacityConnected = () => (
       <Capacity
         capacityTotal={props.capacityTotal}
         capacityUsed={props.capacityUsed}
+        capacityRequested={props.capacityRequested}
+        vmsCapacity={props.vmsCapacity}
+        podsCapacity={props.podsCapacity}
         LoadingComponent={props.LoadingComponent}
       />
     )}

--- a/src/components/StorageOverview/Capacity/fixtures/Capacity.fixture.js
+++ b/src/components/StorageOverview/Capacity/fixtures/Capacity.fixture.js
@@ -13,6 +13,9 @@ const getPromResponse = value => ({
 export const capacityStats = {
   capacityTotal: getPromResponse(11),
   capacityUsed: getPromResponse(5),
+  capacityRequested: getPromResponse(7),
+  vmsCapacity: getPromResponse(3),
+  podsCapacity: getPromResponse(10),
 };
 
 export default [

--- a/src/components/StorageOverview/Capacity/strings.js
+++ b/src/components/StorageOverview/Capacity/strings.js
@@ -1,0 +1,3 @@
+export const TOTAL = 'Total Capacity';
+export const CAPACITY = 'Requested vs Used';
+export const VMSVSPODS = 'VMs vs Pods';

--- a/src/components/StorageOverview/Capacity/tests/Capacity.test.js
+++ b/src/components/StorageOverview/Capacity/tests/Capacity.test.js
@@ -1,13 +1,23 @@
 import React from 'react';
-import { render, shallow } from 'enzyme';
+import { render, shallow, mount } from 'enzyme';
 
 import { Capacity, CapacityConnected } from '../Capacity';
 import { default as CapacityFixtures } from '../fixtures/Capacity.fixture';
 import { default as StorageOverviewFixtures } from '../../fixtures/StorageOverview.fixture';
 import { StorageOverviewContext } from '../../StorageOverviewContext';
+import { selectDropdownItem } from '../../../../tests/enzyme';
+
+import { TOTAL, CAPACITY } from '../strings';
 
 // eslint-disable-next-line react/prop-types
 const testCapacityOverview = ({ props }) => <Capacity {...props} />;
+
+const getCapacityDropdown = component => component.find('#capacity-type');
+
+const testCapacityResults = (component, capacity) => {
+  selectDropdownItem(getCapacityDropdown(component), capacity);
+  expect(component.state().capacity).toBe(capacity);
+};
 
 describe('<Capacity />', () => {
   CapacityFixtures.forEach(fixture => {
@@ -15,6 +25,11 @@ describe('<Capacity />', () => {
       const component = shallow(testCapacityOverview(fixture));
       expect(component).toMatchSnapshot();
     });
+  });
+  it('switches between capacity dropdown options', () => {
+    const component = mount(testCapacityOverview(CapacityFixtures[0]));
+    expect(component.state().capacity).toBe(TOTAL);
+    testCapacityResults(component, CAPACITY);
   });
   it('renders correctly with Provider', () => {
     const component = render(

--- a/src/components/StorageOverview/Capacity/tests/__snapshots__/Capacity.test.js.snap
+++ b/src/components/StorageOverview/Capacity/tests/__snapshots__/Capacity.test.js.snap
@@ -7,11 +7,47 @@ exports[`<Capacity /> renders Capacity correctly 1`] = `
   <DashboardCardHeader
     className={null}
   >
-    <DashboardCardTitle
-      className={null}
+    <Row
+      bsClass="row"
+      componentClass="div"
     >
-      Capacity
-    </DashboardCardTitle>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        lg={6}
+        md={6}
+        sm={6}
+        xs={6}
+      >
+        <DashboardCardTitle
+          className={null}
+        >
+          Capacity
+        </DashboardCardTitle>
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+      >
+        <DashboardCardActionsBody>
+          <Dropdown
+            choices={
+              Array [
+                "Total Capacity",
+                "Requested vs Used",
+                "VMs vs Pods",
+              ]
+            }
+            disabled={false}
+            groupClassName="kubevirt-dropdown__group"
+            id="capacity-type"
+            onChange={[Function]}
+            value="Total Capacity"
+            withTooltips={false}
+          />
+        </DashboardCardActionsBody>
+      </Col>
+    </Row>
   </DashboardCardHeader>
   <DashboardCardBody
     LoadingComponent={[Function]}
@@ -23,7 +59,7 @@ exports[`<Capacity /> renders Capacity correctly 1`] = `
         formatValue={[Function]}
         id="capacity"
         isLoading={false}
-        title="Total capacity"
+        title="Total Capacity"
         total={11}
         used={5}
       />
@@ -39,11 +75,47 @@ exports[`<Capacity /> renders Loading Capacity correctly 1`] = `
   <DashboardCardHeader
     className={null}
   >
-    <DashboardCardTitle
-      className={null}
+    <Row
+      bsClass="row"
+      componentClass="div"
     >
-      Capacity
-    </DashboardCardTitle>
+      <Col
+        bsClass="col"
+        componentClass="div"
+        lg={6}
+        md={6}
+        sm={6}
+        xs={6}
+      >
+        <DashboardCardTitle
+          className={null}
+        >
+          Capacity
+        </DashboardCardTitle>
+      </Col>
+      <Col
+        bsClass="col"
+        componentClass="div"
+      >
+        <DashboardCardActionsBody>
+          <Dropdown
+            choices={
+              Array [
+                "Total Capacity",
+                "Requested vs Used",
+                "VMs vs Pods",
+              ]
+            }
+            disabled={true}
+            groupClassName="kubevirt-dropdown__group"
+            id="capacity-type"
+            onChange={[Function]}
+            value="Total Capacity"
+            withTooltips={false}
+          />
+        </DashboardCardActionsBody>
+      </Col>
+    </Row>
   </DashboardCardHeader>
   <DashboardCardBody
     LoadingComponent={[Function]}
@@ -55,7 +127,7 @@ exports[`<Capacity /> renders Loading Capacity correctly 1`] = `
         formatValue={[Function]}
         id="capacity"
         isLoading={true}
-        title="Total capacity"
+        title="Total Capacity"
         total={null}
         used={null}
       />
@@ -71,11 +143,90 @@ exports[`<Capacity /> renders correctly with Provider 1`] = `
   <div
     class="card-pf-heading kubevirt-dashboard__card-heading"
   >
-    <h2
-      class="card-pf-title kubevirt-dashboard__card-title"
+    <div
+      class="row"
     >
-      Capacity
-    </h2>
+      <div
+        class="col-lg-6 col-md-6 col-sm-6 col-xs-6"
+      >
+        <h2
+          class="card-pf-title kubevirt-dashboard__card-title"
+        >
+          Capacity
+        </h2>
+      </div>
+      <div
+        class=""
+      >
+        <div
+          class="kubevirt-dashboard__actions-body"
+        >
+          <div
+            class="kubevirt-dropdown__group btn-group btn-group-justified"
+          >
+            <div
+              class="dropdown btn-group btn-group-default"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="kubevirt-dropdown dropdown-toggle btn btn-default"
+                id="capacity-type"
+                role="button"
+                type="button"
+              >
+                Total Capacity 
+                <span
+                  class="caret"
+                />
+              </button>
+              <ul
+                aria-labelledby="capacity-type"
+                class="dropdown-menu"
+                role="menu"
+              >
+                <li
+                  class=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    Total Capacity
+                  </a>
+                </li>
+                <li
+                  class=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    Requested vs Used
+                  </a>
+                </li>
+                <li
+                  class=""
+                  role="presentation"
+                >
+                  <a
+                    href="#"
+                    role="menuitem"
+                    tabindex="-1"
+                  >
+                    VMs vs Pods
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <div
     class="card-pf-body"
@@ -89,7 +240,7 @@ exports[`<Capacity /> renders correctly with Provider 1`] = `
         <div
           class="kubevirt-capacity__item-title"
         >
-          Total capacity
+          Total Capacity
         </div>
         <h6
           class="kubevirt-capacity__item-description"

--- a/src/constants/storage.js
+++ b/src/constants/storage.js
@@ -1,8 +1,14 @@
 export const STORAGE_PROMETHEUS_QUERIES = {
   // from storage
   CEPH_STATUS_QUERY: 'ceph_health_status',
-  STORAGE_CEPH_CAPACITY_TOTAL_QUERY: 'ceph_cluster_total_bytes',
-  STORAGE_CEPH_CAPACITY_USED_QUERY: 'ceph_cluster_total_used_bytes',
+  STORAGE_CEPH_CAPACITY_TOTAL_QUERY: 'sum(max(kubelet_volume_stats_capacity_bytes) by (persistentvolumeclaim))',
+  STORAGE_CEPH_CAPACITY_USED_QUERY: 'sum(max(kubelet_volume_stats_used_bytes) by (persistentvolumeclaim))',
+  STORAGE_CEPH_CAPACITY_REQUESTED_QUERY:
+    'sum(max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (persistentvolumeclaim))',
+  STORAGE_CEPH_CAPACITY_VMS_QUERY:
+    '(sort(topk(5, sum(avg_over_time(kube_persistentvolumeclaim_resource_requests_storage_bytes[1h]) * on (namespace,persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~"virt-launcher-.*"}) by (pod))))',
+  STORAGE_CEPH_CAPACITY_PODS_QUERY:
+    '(sort(topk(5, sum(avg_over_time(kube_persistentvolumeclaim_resource_requests_storage_bytes[1h]) * on (namespace,persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info) by (pod))))',
   CEPH_OSD_UP_QUERY: 'sum(ceph_osd_up)',
   CEPH_OSD_DOWN_QUERY: 'count(ceph_osd_up == 0.0) OR vector(0)',
 


### PR DESCRIPTION
Implemented the dropdown options for the Capacity card.
1. Total Capacity
2. Requested vs Used
3. VMs vs Pods

![Screenshot from 2019-06-04 16-31-31](https://user-images.githubusercontent.com/27074500/58874369-49c8b080-86e6-11e9-9603-ecb7143e2a2f.png)

The queries haven't been tested yet and will be changed, if needed.
