### PR TITLE
fix: reset OS when re-selecting VM for import

### DIFF
--- a/src/components/Wizard/CreateVmWizard/stateUpdate/providers/prefillVmStateUpdate.js
+++ b/src/components/Wizard/CreateVmWizard/stateUpdate/providers/prefillVmStateUpdate.js
@@ -47,20 +47,20 @@ export const prefilUpdateCreator = (prevProps, prevState, props, state) => {
       [VM_SETTINGS_TAB_KEY]: {
         value: {
           [NAME_KEY]: {
-            value: get(parsedVm, ['Config', 'Name']),
+            value: get(parsedVm, ['Config', 'Name'], null),
           },
           [DESCRIPTION_KEY]: {
-            value: get(parsedVm, ['Config', 'Annotation']),
+            value: get(parsedVm, ['Config', 'Annotation'], null),
           },
           [MEMORY_KEY]: {
-            value: memory ? memory / 1024 : undefined,
+            value: memory ? memory / 1024 : null,
           },
           [CPU_KEY]: {
-            value: get(parsedVm, ['Config', 'Hardware', 'NumCPU']),
+            value: get(parsedVm, ['Config', 'Hardware', 'NumCPU'], null),
           },
           [OPERATING_SYSTEM_KEY]: {
-            value: undefined || os,
-            guestFullName: get(parsedVm, ['Config', 'GuestFullName']),
+            value: os || null,
+            guestFullName: get(parsedVm, ['Config', 'GuestFullName'], null),
           },
           [FLAVOR_KEY]: {
             value: CUSTOM_FLAVOR,


### PR DESCRIPTION
- Once operating system is picked, Operating system for another VM is now detected

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1710932