### PR TITLE
Fix save vCenter credentials functionality

### DIFF
--- a/src/components/Wizard/CreateVmWizard/initialState/providers/vmWareInitialState.js
+++ b/src/components/Wizard/CreateVmWizard/initialState/providers/vmWareInitialState.js
@@ -10,6 +10,9 @@ import {
   PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY,
   PROVIDER_VMWARE_VCENTER_KEY,
   PROVIDER_VMWARE_VM_KEY,
+  PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_SAVE,
 } from '../../providers/VMwareImportProvider/constants';
 import { getSimpleV2vVMwareStatus } from '../../../../../utils/status/v2vVMware/v2vVMwareStatus';
 
@@ -29,7 +32,7 @@ export const getVmWareInitialState = props => ({
   [PROVIDER_VMWARE_CHECK_CONNECTION_KEY]: {
     isDisabled: asDisabled(true, PROVIDER_VMWARE_VCENTER_KEY),
   },
-  [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: {},
+  [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: { value: true },
   [PROVIDER_VMWARE_VM_KEY]: {
     isDisabled: asDisabled(true, PROVIDER_VMWARE_VM_KEY),
   },
@@ -40,6 +43,8 @@ export const getVmWareInitialState = props => ({
 
   // simple values
   [PROVIDER_VMWARE_V2V_NAME_KEY]: null,
+  [PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY]: null,
+  [PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY]: PROVIDER_VMWARE_CHECK_CONNECTION_BTN_SAVE,
 });
 
 const titleResolver = {
@@ -47,7 +52,7 @@ const titleResolver = {
   [PROVIDER_VMWARE_HOSTNAME_KEY]: 'vCenter Hostname',
   [PROVIDER_VMWARE_USER_NAME_KEY]: 'vCenter User Name',
   [PROVIDER_VMWARE_USER_PASSWORD_KEY]: 'vCenter Password',
-  [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: 'Remember vCenter credentials',
+  [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: 'Save as New vCenter Instance',
   [PROVIDER_VMWARE_VM_KEY]: 'VM to Import',
 };
 
@@ -75,7 +80,7 @@ const helpResolver = {
   [PROVIDER_VMWARE_USER_NAME_KEY]: () => 'User name to be used for connection to a vCenter instance.',
   [PROVIDER_VMWARE_USER_PASSWORD_KEY]: () => 'User password to be used for connection to a vCenter instance.',
   [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: () =>
-    'If checked, new secret keeping connection details will be created for later use.',
+    'If checked, a new secret containing the connection details will be created for future use.',
   [PROVIDER_VMWARE_VM_KEY]: () =>
     'Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded.',
 };

--- a/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/VMWareImportProvider.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/VMWareImportProvider.js
@@ -26,6 +26,7 @@ import { FormRow } from '../../../../Form/FormRow';
 import { CONNECT_TO_NEW_INSTANCE } from '../../strings';
 import {
   PROVIDER_VMWARE,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY,
   PROVIDER_VMWARE_CHECK_CONNECTION_KEY,
   PROVIDER_VMWARE_HOSTNAME_KEY,
   PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY,
@@ -180,7 +181,7 @@ export class VMWareImportProvider extends React.Component {
             disabled={isFieldDisabled(this.getField(PROVIDER_VMWARE_CHECK_CONNECTION_KEY))}
             onClick={() => this.onChange(PROVIDER_VMWARE_CHECK_CONNECTION_KEY, true)}
           >
-            Check
+            {this.getField(PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY)}
           </Button>
         </FormRow>
         <FormRow isHidden={isFieldHidden(this.getField(PROVIDER_VMWARE_STATUS_KEY))}>

--- a/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/constants.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/constants.js
@@ -7,8 +7,12 @@ export const PROVIDER_VMWARE_USER_PASSWORD_KEY = 'vmwarePassword';
 export const PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY = 'rememberVMwareCredentials';
 
 export const PROVIDER_VMWARE_CHECK_CONNECTION_KEY = 'checkConnectionButton';
+export const PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY = 'checkConnectionButtonText';
+export const PROVIDER_VMWARE_CHECK_CONNECTION_BTN_SAVE = 'Check and Save';
+export const PROVIDER_VMWARE_CHECK_CONNECTION_BTN_DONT_SAVE = 'Check';
 export const PROVIDER_VMWARE_STATUS_KEY = 'vmwareStatus';
 
 export const PROVIDER_VMWARE_VM_KEY = 'vmwareVm';
 
 export const PROVIDER_VMWARE_V2V_NAME_KEY = 'v2vVmwareName';
+export const PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY = 'newVCenterName';

--- a/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/fixtures/VMWareImportProvider.fixture.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/fixtures/VMWareImportProvider.fixture.js
@@ -1,1 +1,34 @@
-// TODO: add
+import { PROVIDERS_DATA_KEY } from '../../../constants';
+import { PROVIDER_VMWARE, PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY, PROVIDER_VMWARE_STATUS_KEY } from '../constants';
+import { V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL } from '../../../../../../utils/status/v2vVMware';
+import { VMWareImportProvider } from '../VMWareImportProvider';
+
+export const vmSettingsConnectionSuccessful = {
+  [PROVIDERS_DATA_KEY]: {
+    [PROVIDER_VMWARE]: {
+      [PROVIDER_VMWARE_STATUS_KEY]: {
+        value: V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL,
+      },
+    },
+  },
+};
+
+export const vmSettingsDontSaveCredentials = {
+  [PROVIDERS_DATA_KEY]: {
+    [PROVIDER_VMWARE]: {
+      [PROVIDER_VMWARE_STATUS_KEY]: {
+        value: V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL,
+      },
+      [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: {
+        value: false,
+      },
+    },
+  },
+};
+
+export default {
+  component: VMWareImportProvider,
+  props: {
+    vmSettings: vmSettingsConnectionSuccessful,
+  },
+};

--- a/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/tests/VMWareImportProvider.test.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/tests/VMWareImportProvider.test.js
@@ -2,6 +2,10 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import { VMWareImportProvider } from '../VMWareImportProvider';
+import {
+  vmSettingsConnectionSuccessful,
+  vmSettingsDontSaveCredentials,
+} from '../fixtures/VMWareImportProvider.fixture';
 
 const testVMWareImportProvider = () => <VMWareImportProvider />;
 
@@ -9,6 +13,16 @@ const testVMWareImportProvider = () => <VMWareImportProvider />;
 describe('<VMWareImportProvider />', () => {
   it('renders correctly', () => {
     const component = mount(testVMWareImportProvider());
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders correctly when connection is successful', () => {
+    const component = mount(<VMWareImportProvider vmSettings={vmSettingsConnectionSuccessful} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders correctly when password is not saved', () => {
+    const component = mount(<VMWareImportProvider vmSettings={vmSettingsDontSaveCredentials} />);
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/tests/__snapshots__/VMWareImportProvider.test.js.snap
+++ b/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/tests/__snapshots__/VMWareImportProvider.test.js.snap
@@ -813,7 +813,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
   <FormRow
     className="kubevirt-create-vm-wizard__import-vmware-password"
     controlSize={5}
-    help="If checked, new secret keeping connection details will be created for later use."
+    help="If checked, a new secret containing the connection details will be created for future use."
     id={null}
     isHidden={false}
     isRequired={false}
@@ -826,7 +826,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
     <ValidationFormRow
       className="kubevirt-create-vm-wizard__import-vmware-password"
       controlSize={5}
-      help="If checked, new secret keeping connection details will be created for later use."
+      help="If checked, a new secret containing the connection details will be created for future use."
       id={null}
       isHidden={false}
       isRequired={false}
@@ -854,7 +854,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
               className="text-right col-sm-3"
             >
               <FormControlLabel
-                help="If checked, new secret keeping connection details will be created for later use."
+                help="If checked, a new secret containing the connection details will be created for future use."
                 isRequired={false}
                 title=""
               >
@@ -870,7 +870,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
                 <FieldLevelHelp
                   buttonClass=""
                   className="kubevirt-form-group__field-help"
-                  content="If checked, new secret keeping connection details will be created for later use."
+                  content="If checked, a new secret containing the connection details will be created for future use."
                   placement="right"
                   rootClose={true}
                 >
@@ -882,7 +882,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
                         id="popover"
                         placement="right"
                       >
-                        If checked, new secret keeping connection details will be created for later use.
+                        If checked, a new secret containing the connection details will be created for future use.
                       </Popover>
                     }
                     placement="right"
@@ -943,7 +943,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
                 id="vcenter-remember-credentials"
                 onBlur={[Function]}
                 onChange={[Function]}
-                title="Remember vCenter credentials"
+                title="Save as New vCenter Instance"
               >
                 <Checkbox
                   bsClass="checkbox"
@@ -969,7 +969,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
                         onChange={[Function]}
                         type="checkbox"
                       />
-                      Remember vCenter credentials
+                      Save as New vCenter Instance
                     </label>
                   </div>
                 </Checkbox>
@@ -1063,9 +1063,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
                   id="vcenter-connect"
                   onClick={[Function]}
                   type="button"
-                >
-                  Check
-                </button>
+                />
               </Button>
             </div>
           </Col>
@@ -1152,6 +1150,2893 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
                     </div>
                   </StatusField>
                 </ConnectionUnknown>
+              </VMWareProviderStatus>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help="Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="vmwareVm"
+    labelSize={3}
+    textPosition="text-right"
+    title="VM to Import"
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help="Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title="VM to Import"
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded."
+                isRequired={false}
+                title="VM to Import"
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  >
+                    VM to Import
+                  </label>
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded.
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Dropdown
+                choices={Array []}
+                disabled={false}
+                id="vcenter-vm-dropdown"
+                onChange={[Function]}
+                value="--- Select VM ---"
+                withTooltips={false}
+              >
+                <ButtonGroup
+                  block={false}
+                  bsClass="btn-group"
+                  justified={true}
+                  key="vcenter-vm-dropdown"
+                  vertical={false}
+                >
+                  <div
+                    className="btn-group btn-group-justified"
+                  >
+                    <DropdownButton
+                      bsStyle="default"
+                      className="kubevirt-dropdown"
+                      disabled={false}
+                      id="vcenter-vm-dropdown"
+                      onSelect={[Function]}
+                      title="--- Select VM ---"
+                    >
+                      <DropdownButton
+                        bsStyle="default"
+                        className="kubevirt-dropdown"
+                        disabled={false}
+                        id="vcenter-vm-dropdown"
+                        onSelect={[Function]}
+                        title="--- Select VM ---"
+                      >
+                        <Uncontrolled(Dropdown)
+                          bsStyle="default"
+                          disabled={false}
+                          id="vcenter-vm-dropdown"
+                          onSelect={[Function]}
+                        >
+                          <Dropdown
+                            bsClass="dropdown"
+                            bsStyle="default"
+                            componentClass={[Function]}
+                            disabled={false}
+                            id="vcenter-vm-dropdown"
+                            onSelect={[Function]}
+                            onToggle={[Function]}
+                          >
+                            <ButtonGroup
+                              block={false}
+                              bsClass="btn-group"
+                              bsStyle="default"
+                              className="dropdown"
+                              justified={false}
+                              vertical={false}
+                            >
+                              <div
+                                className="dropdown btn-group btn-group-default"
+                              >
+                                <DropdownToggle
+                                  bsClass="dropdown-toggle"
+                                  bsRole="toggle"
+                                  bsStyle="default"
+                                  className="kubevirt-dropdown"
+                                  disabled={false}
+                                  id="vcenter-vm-dropdown"
+                                  key=".0"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  open={false}
+                                  useAnchor={false}
+                                >
+                                  <Button
+                                    active={false}
+                                    aria-expanded={false}
+                                    aria-haspopup={true}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="default"
+                                    className="kubevirt-dropdown dropdown-toggle"
+                                    disabled={false}
+                                    id="vcenter-vm-dropdown"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    role="button"
+                                  >
+                                    <button
+                                      aria-expanded={false}
+                                      aria-haspopup={true}
+                                      className="kubevirt-dropdown dropdown-toggle btn btn-default"
+                                      disabled={false}
+                                      id="vcenter-vm-dropdown"
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
+                                      role="button"
+                                      type="button"
+                                    >
+                                      --- Select VM ---
+                                       
+                                      <span
+                                        className="caret"
+                                      />
+                                    </button>
+                                  </Button>
+                                </DropdownToggle>
+                                <DropdownMenu
+                                  bsClass="dropdown-menu"
+                                  bsRole="menu"
+                                  key=".1"
+                                  labelledBy="vcenter-vm-dropdown"
+                                  onClose={[Function]}
+                                  onSelect={[Function]}
+                                  pullRight={false}
+                                >
+                                  <RootCloseWrapper
+                                    disabled={true}
+                                    event="click"
+                                    onRootClose={[Function]}
+                                  >
+                                    <ul
+                                      aria-labelledby="vcenter-vm-dropdown"
+                                      className="dropdown-menu"
+                                      role="menu"
+                                    />
+                                  </RootCloseWrapper>
+                                </DropdownMenu>
+                              </div>
+                            </ButtonGroup>
+                          </Dropdown>
+                        </Uncontrolled(Dropdown)>
+                      </DropdownButton>
+                    </DropdownButton>
+                  </div>
+                </ButtonGroup>
+              </Dropdown>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+</VMWareImportProvider>
+`;
+
+exports[`<VMWareImportProvider /> renders correctly when connection is successful 1`] = `
+<VMWareImportProvider
+  v2vvmware={null}
+  vCenterSecrets={Array []}
+  vmSettings={
+    Object {
+      "providersData": Object {
+        "VMware": Object {
+          "vmwareStatus": Object {
+            "value": "V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL",
+          },
+        },
+      },
+    }
+  }
+  vmwareToKubevirtOsConfigMap={null}
+>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help="Select secret containing connection details for a vCenter instance."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="vCenterInstance"
+    labelSize={3}
+    textPosition="text-right"
+    title="vCenter Instance"
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help="Select secret containing connection details for a vCenter instance."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title="vCenter Instance"
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="Select secret containing connection details for a vCenter instance."
+                isRequired={false}
+                title="vCenter Instance"
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  >
+                    vCenter Instance
+                  </label>
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="Select secret containing connection details for a vCenter instance."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        Select secret containing connection details for a vCenter instance.
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Dropdown
+                choices={
+                  Array [
+                    "Connect to New Instance",
+                  ]
+                }
+                disabled={false}
+                id="vcenter-instance-dropdown"
+                onChange={[Function]}
+                value="--- Select vCenter Instance Secret ---"
+                withTooltips={false}
+              >
+                <ButtonGroup
+                  block={false}
+                  bsClass="btn-group"
+                  justified={true}
+                  key="vcenter-instance-dropdown"
+                  vertical={false}
+                >
+                  <div
+                    className="btn-group btn-group-justified"
+                  >
+                    <DropdownButton
+                      bsStyle="default"
+                      className="kubevirt-dropdown"
+                      disabled={false}
+                      id="vcenter-instance-dropdown"
+                      onSelect={[Function]}
+                      title="--- Select vCenter Instance Secret ---"
+                    >
+                      <DropdownButton
+                        bsStyle="default"
+                        className="kubevirt-dropdown"
+                        disabled={false}
+                        id="vcenter-instance-dropdown"
+                        onSelect={[Function]}
+                        title="--- Select vCenter Instance Secret ---"
+                      >
+                        <Uncontrolled(Dropdown)
+                          bsStyle="default"
+                          disabled={false}
+                          id="vcenter-instance-dropdown"
+                          onSelect={[Function]}
+                        >
+                          <Dropdown
+                            bsClass="dropdown"
+                            bsStyle="default"
+                            componentClass={[Function]}
+                            disabled={false}
+                            id="vcenter-instance-dropdown"
+                            onSelect={[Function]}
+                            onToggle={[Function]}
+                          >
+                            <ButtonGroup
+                              block={false}
+                              bsClass="btn-group"
+                              bsStyle="default"
+                              className="dropdown"
+                              justified={false}
+                              vertical={false}
+                            >
+                              <div
+                                className="dropdown btn-group btn-group-default"
+                              >
+                                <DropdownToggle
+                                  bsClass="dropdown-toggle"
+                                  bsRole="toggle"
+                                  bsStyle="default"
+                                  className="kubevirt-dropdown"
+                                  disabled={false}
+                                  id="vcenter-instance-dropdown"
+                                  key=".0"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  open={false}
+                                  useAnchor={false}
+                                >
+                                  <Button
+                                    active={false}
+                                    aria-expanded={false}
+                                    aria-haspopup={true}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="default"
+                                    className="kubevirt-dropdown dropdown-toggle"
+                                    disabled={false}
+                                    id="vcenter-instance-dropdown"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    role="button"
+                                  >
+                                    <button
+                                      aria-expanded={false}
+                                      aria-haspopup={true}
+                                      className="kubevirt-dropdown dropdown-toggle btn btn-default"
+                                      disabled={false}
+                                      id="vcenter-instance-dropdown"
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
+                                      role="button"
+                                      type="button"
+                                    >
+                                      --- Select vCenter Instance Secret ---
+                                       
+                                      <span
+                                        className="caret"
+                                      />
+                                    </button>
+                                  </Button>
+                                </DropdownToggle>
+                                <DropdownMenu
+                                  bsClass="dropdown-menu"
+                                  bsRole="menu"
+                                  key=".1"
+                                  labelledBy="vcenter-instance-dropdown"
+                                  onClose={[Function]}
+                                  onSelect={[Function]}
+                                  pullRight={false}
+                                >
+                                  <RootCloseWrapper
+                                    disabled={true}
+                                    event="click"
+                                    onRootClose={[Function]}
+                                  >
+                                    <ul
+                                      aria-labelledby="vcenter-instance-dropdown"
+                                      className="dropdown-menu"
+                                      role="menu"
+                                    >
+                                      <MenuItem
+                                        bsClass="dropdown"
+                                        disabled={false}
+                                        divider={false}
+                                        eventKey="Connect to New Instance"
+                                        header={false}
+                                        key=".$Connect to New Instance"
+                                        onKeyDown={[Function]}
+                                        onSelect={[Function]}
+                                      >
+                                        <li
+                                          className=""
+                                          role="presentation"
+                                        >
+                                          <SafeAnchor
+                                            componentClass="a"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            role="menuitem"
+                                            tabIndex="-1"
+                                          >
+                                            <a
+                                              href="#"
+                                              onClick={[Function]}
+                                              onKeyDown={[Function]}
+                                              role="menuitem"
+                                              tabIndex="-1"
+                                            >
+                                              Connect to New Instance
+                                            </a>
+                                          </SafeAnchor>
+                                        </li>
+                                      </MenuItem>
+                                    </ul>
+                                  </RootCloseWrapper>
+                                </DropdownMenu>
+                              </div>
+                            </ButtonGroup>
+                          </Dropdown>
+                        </Uncontrolled(Dropdown)>
+                      </DropdownButton>
+                    </DropdownButton>
+                  </div>
+                </ButtonGroup>
+              </Dropdown>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help="Address to be used for connection to a vCenter instance. The \\"https://\\" protocol will be added automatically. Example: \\"my.domain.com:1234\\"."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="vmwareHostname"
+    labelSize={3}
+    textPosition="text-right"
+    title="vCenter Hostname"
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help="Address to be used for connection to a vCenter instance. The \\"https://\\" protocol will be added automatically. Example: \\"my.domain.com:1234\\"."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title="vCenter Hostname"
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="Address to be used for connection to a vCenter instance. The \\"https://\\" protocol will be added automatically. Example: \\"my.domain.com:1234\\"."
+                isRequired={false}
+                title="vCenter Hostname"
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  >
+                    vCenter Hostname
+                  </label>
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="Address to be used for connection to a vCenter instance. The \\"https://\\" protocol will be added automatically. Example: \\"my.domain.com:1234\\"."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        Address to be used for connection to a vCenter instance. The "https://" protocol will be added automatically. Example: "my.domain.com:1234".
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Text
+                disabled={false}
+                id="vcenter-hostname-dropdown"
+                onBlur={[Function]}
+                onChange={[Function]}
+                type="text"
+                value=""
+              >
+                <FormControl
+                  bsClass="form-control"
+                  componentClass="input"
+                  disabled={false}
+                  id="vcenter-hostname-dropdown"
+                  key="vcenter-hostname-dropdown"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  type="text"
+                  value=""
+                >
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="vcenter-hostname-dropdown"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    type="text"
+                    value=""
+                  />
+                </FormControl>
+              </Text>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help="User name to be used for connection to a vCenter instance."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="vmwareUserName"
+    labelSize={3}
+    textPosition="text-right"
+    title="vCenter User Name"
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help="User name to be used for connection to a vCenter instance."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title="vCenter User Name"
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="User name to be used for connection to a vCenter instance."
+                isRequired={false}
+                title="vCenter User Name"
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  >
+                    vCenter User Name
+                  </label>
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="User name to be used for connection to a vCenter instance."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        User name to be used for connection to a vCenter instance.
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Text
+                disabled={false}
+                id="vcenter-username"
+                onBlur={[Function]}
+                onChange={[Function]}
+                type="text"
+                value=""
+              >
+                <FormControl
+                  bsClass="form-control"
+                  componentClass="input"
+                  disabled={false}
+                  id="vcenter-username"
+                  key="vcenter-username"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  type="text"
+                  value=""
+                >
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="vcenter-username"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    type="text"
+                    value=""
+                  />
+                </FormControl>
+              </Text>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help="User password to be used for connection to a vCenter instance."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="vmwarePassword"
+    labelSize={3}
+    textPosition="text-right"
+    title="vCenter Password"
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help="User password to be used for connection to a vCenter instance."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title="vCenter Password"
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="User password to be used for connection to a vCenter instance."
+                isRequired={false}
+                title="vCenter Password"
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  >
+                    vCenter Password
+                  </label>
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="User password to be used for connection to a vCenter instance."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        User password to be used for connection to a vCenter instance.
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Text
+                disabled={false}
+                id="vcenter-password"
+                onBlur={[Function]}
+                onChange={[Function]}
+                type="password"
+                value=""
+              >
+                <FormControl
+                  bsClass="form-control"
+                  componentClass="input"
+                  disabled={false}
+                  id="vcenter-password"
+                  key="vcenter-password"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  type="password"
+                  value=""
+                >
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="vcenter-password"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    type="password"
+                    value=""
+                  />
+                </FormControl>
+              </Text>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className="kubevirt-create-vm-wizard__import-vmware-password"
+    controlSize={5}
+    help="If checked, a new secret containing the connection details will be created for future use."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="rememberVMwareCredentials"
+    labelSize={3}
+    textPosition="text-right"
+    title=""
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className="kubevirt-create-vm-wizard__import-vmware-password"
+      controlSize={5}
+      help="If checked, a new secret containing the connection details will be created for future use."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title=""
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group kubevirt-create-vm-wizard__import-vmware-password"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group kubevirt-create-vm-wizard__import-vmware-password form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="If checked, a new secret containing the connection details will be created for future use."
+                isRequired={false}
+                title=""
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  />
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="If checked, a new secret containing the connection details will be created for future use."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        If checked, a new secret containing the connection details will be created for future use.
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Checkbox
+                checked={false}
+                disabled={false}
+                id="vcenter-remember-credentials"
+                onBlur={[Function]}
+                onChange={[Function]}
+                title="Save as New vCenter Instance"
+              >
+                <Checkbox
+                  bsClass="checkbox"
+                  checked={false}
+                  disabled={false}
+                  id="vcenter-remember-credentials"
+                  inline={false}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  title=""
+                >
+                  <div
+                    className="checkbox"
+                  >
+                    <label
+                      title=""
+                    >
+                      <input
+                        checked={false}
+                        disabled={false}
+                        id="vcenter-remember-credentials"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      Save as New vCenter Instance
+                    </label>
+                  </div>
+                </Checkbox>
+              </Checkbox>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help=""
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    labelSize={3}
+    textPosition="text-right"
+    title=""
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help=""
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title=""
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help=""
+                isRequired={false}
+                title=""
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  />
+                </ControlLabel>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
+                bsStyle="default"
+                className="kubevirt-create-vm-wizard__import-vmware-passwordcheck-button"
+                disabled={false}
+                id="vcenter-connect"
+                onClick={[Function]}
+              >
+                <button
+                  className="kubevirt-create-vm-wizard__import-vmware-passwordcheck-button btn btn-default"
+                  disabled={false}
+                  id="vcenter-connect"
+                  onClick={[Function]}
+                  type="button"
+                />
+              </Button>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help=""
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    labelSize={3}
+    textPosition="text-right"
+    title=""
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help=""
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title=""
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help=""
+                isRequired={false}
+                title=""
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  />
+                </ControlLabel>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <VMWareProviderStatus
+                status="V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL"
+              >
+                <ConnectionSuccessful>
+                  <StatusField>
+                    <div
+                      className="kubevirt-create-vm-wizard__import-vmware-connection-status"
+                    >
+                      Connection successful
+                    </div>
+                  </StatusField>
+                </ConnectionSuccessful>
+              </VMWareProviderStatus>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help="Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="vmwareVm"
+    labelSize={3}
+    textPosition="text-right"
+    title="VM to Import"
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help="Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title="VM to Import"
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded."
+                isRequired={false}
+                title="VM to Import"
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  >
+                    VM to Import
+                  </label>
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded.
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Dropdown
+                choices={Array []}
+                disabled={false}
+                id="vcenter-vm-dropdown"
+                onChange={[Function]}
+                value="--- Select VM ---"
+                withTooltips={false}
+              >
+                <ButtonGroup
+                  block={false}
+                  bsClass="btn-group"
+                  justified={true}
+                  key="vcenter-vm-dropdown"
+                  vertical={false}
+                >
+                  <div
+                    className="btn-group btn-group-justified"
+                  >
+                    <DropdownButton
+                      bsStyle="default"
+                      className="kubevirt-dropdown"
+                      disabled={false}
+                      id="vcenter-vm-dropdown"
+                      onSelect={[Function]}
+                      title="--- Select VM ---"
+                    >
+                      <DropdownButton
+                        bsStyle="default"
+                        className="kubevirt-dropdown"
+                        disabled={false}
+                        id="vcenter-vm-dropdown"
+                        onSelect={[Function]}
+                        title="--- Select VM ---"
+                      >
+                        <Uncontrolled(Dropdown)
+                          bsStyle="default"
+                          disabled={false}
+                          id="vcenter-vm-dropdown"
+                          onSelect={[Function]}
+                        >
+                          <Dropdown
+                            bsClass="dropdown"
+                            bsStyle="default"
+                            componentClass={[Function]}
+                            disabled={false}
+                            id="vcenter-vm-dropdown"
+                            onSelect={[Function]}
+                            onToggle={[Function]}
+                          >
+                            <ButtonGroup
+                              block={false}
+                              bsClass="btn-group"
+                              bsStyle="default"
+                              className="dropdown"
+                              justified={false}
+                              vertical={false}
+                            >
+                              <div
+                                className="dropdown btn-group btn-group-default"
+                              >
+                                <DropdownToggle
+                                  bsClass="dropdown-toggle"
+                                  bsRole="toggle"
+                                  bsStyle="default"
+                                  className="kubevirt-dropdown"
+                                  disabled={false}
+                                  id="vcenter-vm-dropdown"
+                                  key=".0"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  open={false}
+                                  useAnchor={false}
+                                >
+                                  <Button
+                                    active={false}
+                                    aria-expanded={false}
+                                    aria-haspopup={true}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="default"
+                                    className="kubevirt-dropdown dropdown-toggle"
+                                    disabled={false}
+                                    id="vcenter-vm-dropdown"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    role="button"
+                                  >
+                                    <button
+                                      aria-expanded={false}
+                                      aria-haspopup={true}
+                                      className="kubevirt-dropdown dropdown-toggle btn btn-default"
+                                      disabled={false}
+                                      id="vcenter-vm-dropdown"
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
+                                      role="button"
+                                      type="button"
+                                    >
+                                      --- Select VM ---
+                                       
+                                      <span
+                                        className="caret"
+                                      />
+                                    </button>
+                                  </Button>
+                                </DropdownToggle>
+                                <DropdownMenu
+                                  bsClass="dropdown-menu"
+                                  bsRole="menu"
+                                  key=".1"
+                                  labelledBy="vcenter-vm-dropdown"
+                                  onClose={[Function]}
+                                  onSelect={[Function]}
+                                  pullRight={false}
+                                >
+                                  <RootCloseWrapper
+                                    disabled={true}
+                                    event="click"
+                                    onRootClose={[Function]}
+                                  >
+                                    <ul
+                                      aria-labelledby="vcenter-vm-dropdown"
+                                      className="dropdown-menu"
+                                      role="menu"
+                                    />
+                                  </RootCloseWrapper>
+                                </DropdownMenu>
+                              </div>
+                            </ButtonGroup>
+                          </Dropdown>
+                        </Uncontrolled(Dropdown)>
+                      </DropdownButton>
+                    </DropdownButton>
+                  </div>
+                </ButtonGroup>
+              </Dropdown>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+</VMWareImportProvider>
+`;
+
+exports[`<VMWareImportProvider /> renders correctly when password is not saved 1`] = `
+<VMWareImportProvider
+  v2vvmware={null}
+  vCenterSecrets={Array []}
+  vmSettings={
+    Object {
+      "providersData": Object {
+        "VMware": Object {
+          "rememberVMwareCredentials": Object {
+            "value": false,
+          },
+          "vmwareStatus": Object {
+            "value": "V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL",
+          },
+        },
+      },
+    }
+  }
+  vmwareToKubevirtOsConfigMap={null}
+>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help="Select secret containing connection details for a vCenter instance."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="vCenterInstance"
+    labelSize={3}
+    textPosition="text-right"
+    title="vCenter Instance"
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help="Select secret containing connection details for a vCenter instance."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title="vCenter Instance"
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="Select secret containing connection details for a vCenter instance."
+                isRequired={false}
+                title="vCenter Instance"
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  >
+                    vCenter Instance
+                  </label>
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="Select secret containing connection details for a vCenter instance."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        Select secret containing connection details for a vCenter instance.
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Dropdown
+                choices={
+                  Array [
+                    "Connect to New Instance",
+                  ]
+                }
+                disabled={false}
+                id="vcenter-instance-dropdown"
+                onChange={[Function]}
+                value="--- Select vCenter Instance Secret ---"
+                withTooltips={false}
+              >
+                <ButtonGroup
+                  block={false}
+                  bsClass="btn-group"
+                  justified={true}
+                  key="vcenter-instance-dropdown"
+                  vertical={false}
+                >
+                  <div
+                    className="btn-group btn-group-justified"
+                  >
+                    <DropdownButton
+                      bsStyle="default"
+                      className="kubevirt-dropdown"
+                      disabled={false}
+                      id="vcenter-instance-dropdown"
+                      onSelect={[Function]}
+                      title="--- Select vCenter Instance Secret ---"
+                    >
+                      <DropdownButton
+                        bsStyle="default"
+                        className="kubevirt-dropdown"
+                        disabled={false}
+                        id="vcenter-instance-dropdown"
+                        onSelect={[Function]}
+                        title="--- Select vCenter Instance Secret ---"
+                      >
+                        <Uncontrolled(Dropdown)
+                          bsStyle="default"
+                          disabled={false}
+                          id="vcenter-instance-dropdown"
+                          onSelect={[Function]}
+                        >
+                          <Dropdown
+                            bsClass="dropdown"
+                            bsStyle="default"
+                            componentClass={[Function]}
+                            disabled={false}
+                            id="vcenter-instance-dropdown"
+                            onSelect={[Function]}
+                            onToggle={[Function]}
+                          >
+                            <ButtonGroup
+                              block={false}
+                              bsClass="btn-group"
+                              bsStyle="default"
+                              className="dropdown"
+                              justified={false}
+                              vertical={false}
+                            >
+                              <div
+                                className="dropdown btn-group btn-group-default"
+                              >
+                                <DropdownToggle
+                                  bsClass="dropdown-toggle"
+                                  bsRole="toggle"
+                                  bsStyle="default"
+                                  className="kubevirt-dropdown"
+                                  disabled={false}
+                                  id="vcenter-instance-dropdown"
+                                  key=".0"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  open={false}
+                                  useAnchor={false}
+                                >
+                                  <Button
+                                    active={false}
+                                    aria-expanded={false}
+                                    aria-haspopup={true}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="default"
+                                    className="kubevirt-dropdown dropdown-toggle"
+                                    disabled={false}
+                                    id="vcenter-instance-dropdown"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    role="button"
+                                  >
+                                    <button
+                                      aria-expanded={false}
+                                      aria-haspopup={true}
+                                      className="kubevirt-dropdown dropdown-toggle btn btn-default"
+                                      disabled={false}
+                                      id="vcenter-instance-dropdown"
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
+                                      role="button"
+                                      type="button"
+                                    >
+                                      --- Select vCenter Instance Secret ---
+                                       
+                                      <span
+                                        className="caret"
+                                      />
+                                    </button>
+                                  </Button>
+                                </DropdownToggle>
+                                <DropdownMenu
+                                  bsClass="dropdown-menu"
+                                  bsRole="menu"
+                                  key=".1"
+                                  labelledBy="vcenter-instance-dropdown"
+                                  onClose={[Function]}
+                                  onSelect={[Function]}
+                                  pullRight={false}
+                                >
+                                  <RootCloseWrapper
+                                    disabled={true}
+                                    event="click"
+                                    onRootClose={[Function]}
+                                  >
+                                    <ul
+                                      aria-labelledby="vcenter-instance-dropdown"
+                                      className="dropdown-menu"
+                                      role="menu"
+                                    >
+                                      <MenuItem
+                                        bsClass="dropdown"
+                                        disabled={false}
+                                        divider={false}
+                                        eventKey="Connect to New Instance"
+                                        header={false}
+                                        key=".$Connect to New Instance"
+                                        onKeyDown={[Function]}
+                                        onSelect={[Function]}
+                                      >
+                                        <li
+                                          className=""
+                                          role="presentation"
+                                        >
+                                          <SafeAnchor
+                                            componentClass="a"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            role="menuitem"
+                                            tabIndex="-1"
+                                          >
+                                            <a
+                                              href="#"
+                                              onClick={[Function]}
+                                              onKeyDown={[Function]}
+                                              role="menuitem"
+                                              tabIndex="-1"
+                                            >
+                                              Connect to New Instance
+                                            </a>
+                                          </SafeAnchor>
+                                        </li>
+                                      </MenuItem>
+                                    </ul>
+                                  </RootCloseWrapper>
+                                </DropdownMenu>
+                              </div>
+                            </ButtonGroup>
+                          </Dropdown>
+                        </Uncontrolled(Dropdown)>
+                      </DropdownButton>
+                    </DropdownButton>
+                  </div>
+                </ButtonGroup>
+              </Dropdown>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help="Address to be used for connection to a vCenter instance. The \\"https://\\" protocol will be added automatically. Example: \\"my.domain.com:1234\\"."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="vmwareHostname"
+    labelSize={3}
+    textPosition="text-right"
+    title="vCenter Hostname"
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help="Address to be used for connection to a vCenter instance. The \\"https://\\" protocol will be added automatically. Example: \\"my.domain.com:1234\\"."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title="vCenter Hostname"
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="Address to be used for connection to a vCenter instance. The \\"https://\\" protocol will be added automatically. Example: \\"my.domain.com:1234\\"."
+                isRequired={false}
+                title="vCenter Hostname"
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  >
+                    vCenter Hostname
+                  </label>
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="Address to be used for connection to a vCenter instance. The \\"https://\\" protocol will be added automatically. Example: \\"my.domain.com:1234\\"."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        Address to be used for connection to a vCenter instance. The "https://" protocol will be added automatically. Example: "my.domain.com:1234".
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Text
+                disabled={false}
+                id="vcenter-hostname-dropdown"
+                onBlur={[Function]}
+                onChange={[Function]}
+                type="text"
+                value=""
+              >
+                <FormControl
+                  bsClass="form-control"
+                  componentClass="input"
+                  disabled={false}
+                  id="vcenter-hostname-dropdown"
+                  key="vcenter-hostname-dropdown"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  type="text"
+                  value=""
+                >
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="vcenter-hostname-dropdown"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    type="text"
+                    value=""
+                  />
+                </FormControl>
+              </Text>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help="User name to be used for connection to a vCenter instance."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="vmwareUserName"
+    labelSize={3}
+    textPosition="text-right"
+    title="vCenter User Name"
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help="User name to be used for connection to a vCenter instance."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title="vCenter User Name"
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="User name to be used for connection to a vCenter instance."
+                isRequired={false}
+                title="vCenter User Name"
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  >
+                    vCenter User Name
+                  </label>
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="User name to be used for connection to a vCenter instance."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        User name to be used for connection to a vCenter instance.
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Text
+                disabled={false}
+                id="vcenter-username"
+                onBlur={[Function]}
+                onChange={[Function]}
+                type="text"
+                value=""
+              >
+                <FormControl
+                  bsClass="form-control"
+                  componentClass="input"
+                  disabled={false}
+                  id="vcenter-username"
+                  key="vcenter-username"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  type="text"
+                  value=""
+                >
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="vcenter-username"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    type="text"
+                    value=""
+                  />
+                </FormControl>
+              </Text>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help="User password to be used for connection to a vCenter instance."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="vmwarePassword"
+    labelSize={3}
+    textPosition="text-right"
+    title="vCenter Password"
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help="User password to be used for connection to a vCenter instance."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title="vCenter Password"
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="User password to be used for connection to a vCenter instance."
+                isRequired={false}
+                title="vCenter Password"
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  >
+                    vCenter Password
+                  </label>
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="User password to be used for connection to a vCenter instance."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        User password to be used for connection to a vCenter instance.
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Text
+                disabled={false}
+                id="vcenter-password"
+                onBlur={[Function]}
+                onChange={[Function]}
+                type="password"
+                value=""
+              >
+                <FormControl
+                  bsClass="form-control"
+                  componentClass="input"
+                  disabled={false}
+                  id="vcenter-password"
+                  key="vcenter-password"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  type="password"
+                  value=""
+                >
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="vcenter-password"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    type="password"
+                    value=""
+                  />
+                </FormControl>
+              </Text>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className="kubevirt-create-vm-wizard__import-vmware-password"
+    controlSize={5}
+    help="If checked, a new secret containing the connection details will be created for future use."
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    key="rememberVMwareCredentials"
+    labelSize={3}
+    textPosition="text-right"
+    title=""
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className="kubevirt-create-vm-wizard__import-vmware-password"
+      controlSize={5}
+      help="If checked, a new secret containing the connection details will be created for future use."
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title=""
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group kubevirt-create-vm-wizard__import-vmware-password"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group kubevirt-create-vm-wizard__import-vmware-password form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help="If checked, a new secret containing the connection details will be created for future use."
+                isRequired={false}
+                title=""
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  />
+                </ControlLabel>
+                <FieldLevelHelp
+                  buttonClass=""
+                  className="kubevirt-form-group__field-help"
+                  content="If checked, a new secret containing the connection details will be created for future use."
+                  placement="right"
+                  rootClose={true}
+                >
+                  <OverlayTrigger
+                    defaultOverlayShown={false}
+                    overlay={
+                      <Popover
+                        bsClass="popover"
+                        id="popover"
+                        placement="right"
+                      >
+                        If checked, a new secret containing the connection details will be created for future use.
+                      </Popover>
+                    }
+                    placement="right"
+                    rootClose={true}
+                    trigger={
+                      Array [
+                        "click",
+                      ]
+                    }
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="link"
+                      className="popover-pf-info"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="popover-pf-info btn btn-link"
+                        disabled={false}
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        <Icon
+                          name="info"
+                          type="pf"
+                        >
+                          <PatternflyIcon
+                            className=""
+                            name="info"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pficon pficon-info"
+                            />
+                          </PatternflyIcon>
+                        </Icon>
+                      </button>
+                    </Button>
+                  </OverlayTrigger>
+                </FieldLevelHelp>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Checkbox
+                checked={false}
+                disabled={false}
+                id="vcenter-remember-credentials"
+                onBlur={[Function]}
+                onChange={[Function]}
+                title="Save as New vCenter Instance"
+              >
+                <Checkbox
+                  bsClass="checkbox"
+                  checked={false}
+                  disabled={false}
+                  id="vcenter-remember-credentials"
+                  inline={false}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  title=""
+                >
+                  <div
+                    className="checkbox"
+                  >
+                    <label
+                      title=""
+                    >
+                      <input
+                        checked={false}
+                        disabled={false}
+                        id="vcenter-remember-credentials"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      Save as New vCenter Instance
+                    </label>
+                  </div>
+                </Checkbox>
+              </Checkbox>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help=""
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    labelSize={3}
+    textPosition="text-right"
+    title=""
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help=""
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title=""
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help=""
+                isRequired={false}
+                title=""
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  />
+                </ControlLabel>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
+                bsStyle="default"
+                className="kubevirt-create-vm-wizard__import-vmware-passwordcheck-button"
+                disabled={false}
+                id="vcenter-connect"
+                onClick={[Function]}
+              >
+                <button
+                  className="kubevirt-create-vm-wizard__import-vmware-passwordcheck-button btn btn-default"
+                  disabled={false}
+                  id="vcenter-connect"
+                  onClick={[Function]}
+                  type="button"
+                />
+              </Button>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </ValidationFormRow>
+  </FormRow>
+  <FormRow
+    className={null}
+    controlSize={5}
+    help=""
+    id={null}
+    isHidden={false}
+    isRequired={false}
+    labelSize={3}
+    textPosition="text-right"
+    title=""
+    validation={Object {}}
+  >
+    <ValidationFormRow
+      className={null}
+      controlSize={5}
+      help=""
+      id={null}
+      isHidden={false}
+      isRequired={false}
+      labelSize={3}
+      textPosition="text-right"
+      title=""
+      validation={Object {}}
+    >
+      <FormGroup
+        bsClass="form-group"
+        className="kubevirt-form-group"
+        id={null}
+      >
+        <div
+          className="kubevirt-form-group form-group"
+          id={null}
+        >
+          <Col
+            bsClass="col"
+            className="text-right"
+            componentClass="div"
+            sm={3}
+          >
+            <div
+              className="text-right col-sm-3"
+            >
+              <FormControlLabel
+                help=""
+                isRequired={false}
+                title=""
+              >
+                <ControlLabel
+                  bsClass="control-label"
+                  className={null}
+                  srOnly={false}
+                >
+                  <label
+                    className="control-label"
+                  />
+                </ControlLabel>
+              </FormControlLabel>
+            </div>
+          </Col>
+          <Col
+            bsClass="col"
+            componentClass="div"
+            sm={5}
+          >
+            <div
+              className="col-sm-5"
+            >
+              <VMWareProviderStatus
+                status="V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL"
+              >
+                <ConnectionSuccessful>
+                  <StatusField>
+                    <div
+                      className="kubevirt-create-vm-wizard__import-vmware-connection-status"
+                    >
+                      Connection successful
+                    </div>
+                  </StatusField>
+                </ConnectionSuccessful>
               </VMWareProviderStatus>
             </div>
           </Col>

--- a/src/components/Wizard/CreateVmWizard/stateUpdate/providers/vmWareStateUpdate.js
+++ b/src/components/Wizard/CreateVmWizard/stateUpdate/providers/vmWareStateUpdate.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, has } from 'lodash';
 
 import {
   VM_SETTINGS_TAB_KEY,
@@ -48,6 +48,10 @@ import {
   PROVIDER_VMWARE_USER_PASSWORD_KEY,
   PROVIDER_VMWARE_VCENTER_KEY,
   PROVIDER_VMWARE_VM_KEY,
+  PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_SAVE,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_DONT_SAVE,
 } from '../../providers/VMwareImportProvider/constants';
 import { vmSettingsCreator } from '../vmSettingsTabStateUpdate';
 import {
@@ -57,7 +61,15 @@ import {
 import { requestVmDetail } from '../../../../../k8s/requests/v2v/requestVmDetail';
 import { prefilUpdateCreator } from './prefillVmStateUpdate';
 import { getSimpleV2vVMwareStatus } from '../../../../../utils/status/v2vVMware/v2vVMwareStatus';
-import { V2V_WMWARE_STATUS_ALL_OK, V2V_WMWARE_STATUS_UNKNOWN } from '../../../../../utils/status/v2vVMware';
+import {
+  V2V_WMWARE_STATUS_ALL_OK,
+  V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL,
+  V2V_WMWARE_STATUS_UNKNOWN,
+} from '../../../../../utils/status/v2vVMware';
+import { addLabelToVmwareSecretPatch, removeLabelFromVmwareSecretPatch } from '../../../../../utils';
+import { VCENTER_TEMPORARY_LABEL } from '../../../../../constants';
+import { SecretModel } from '../../../../../models';
+import { getVmwareConnectionName, getVmwareSecretLabels } from '../../../../../selectors/v2v';
 
 const { info, warn, error } = console;
 
@@ -84,6 +96,8 @@ export const getVmwareProviderStateUpdate = (prevProps, prevState, props, state,
     ...[
       secretUpdateCreator,
       secretValueUpdateCreator,
+      saveSecretUpdateCreator,
+      successfulConnectionUpdateCreator,
       checkConnectionUpdateCreator,
       vmwareNameChangedUpdateCreator,
       vmChangedUpdateCreator,
@@ -236,6 +250,49 @@ export const secretValueUpdateCreator = (prevProps, prevState, props, state, ext
   };
 };
 
+export const successfulConnectionUpdateCreator = (prevProps, prevState, props, state, extra) => {
+  const connectionStatus = getVmwareValue(state, PROVIDER_VMWARE_STATUS_KEY);
+
+  if (connectionStatus !== V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL) {
+    return null;
+  }
+
+  const vCenterName = getVmwareField(state, PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY);
+  const secret = props.vCenterSecrets.find(s => getName(s) === vCenterName);
+  const hasTempLabel = has(getVmwareSecretLabels(secret), VCENTER_TEMPORARY_LABEL);
+  const saveCredentialsRequested = getVmwareValue(state, PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY);
+
+  if (saveCredentialsRequested && hasTempLabel) {
+    const patch = removeLabelFromVmwareSecretPatch(VCENTER_TEMPORARY_LABEL);
+    props.k8sPatch(SecretModel, secret, patch).catch(err => {
+      if (!get(err, 'message').includes('Unable to remove nonexistent key')) {
+        console.error(err); // eslint-disable-line no-console
+      }
+    });
+  }
+
+  if (!saveCredentialsRequested && !hasTempLabel) {
+    const patch = addLabelToVmwareSecretPatch(VCENTER_TEMPORARY_LABEL);
+    props.k8sPatch(SecretModel, secret, patch).catch(err => console.log(err)); // eslint-disable-line no-console
+  }
+
+  return null;
+};
+
+export const saveSecretUpdateCreator = (prevProps, prevState, props, state, extra) => {
+  if (!hasVmWareSettingsValuesChanged(prevState, state, PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY)) {
+    return null;
+  }
+
+  const saveCredentialsRequested = getVmwareValue(state, PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY);
+
+  return {
+    [PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY]: saveCredentialsRequested
+      ? PROVIDER_VMWARE_CHECK_CONNECTION_BTN_SAVE
+      : PROVIDER_VMWARE_CHECK_CONNECTION_BTN_DONT_SAVE,
+  };
+};
+
 export const checkConnectionUpdateCreator = (prevProps, prevState, props, state, extra) => {
   const oldConnect = !!getVmwareValue(prevState, PROVIDER_VMWARE_CHECK_CONNECTION_KEY);
   const connect = !!getVmwareValue(state, PROVIDER_VMWARE_CHECK_CONNECTION_KEY);
@@ -359,6 +416,7 @@ const createConnectionObjects = (props, params, { safeSetState }, afterData) => 
           value: getSimpleV2vVMwareStatus(null, { isConnecting: true }),
         },
         [PROVIDER_VMWARE_V2V_NAME_KEY]: getName(v2vVmware),
+        [PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY]: getVmwareConnectionName(v2vVmware),
       })
     )
     .catch(err => {

--- a/src/components/Wizard/CreateVmWizard/tests/__snapshots__/CreateVmWizard.test.js.snap
+++ b/src/components/Wizard/CreateVmWizard/tests/__snapshots__/CreateVmWizard.test.js.snap
@@ -183,6 +183,7 @@ Object {
           "vCenterInstance": true,
         },
       },
+      "checkConnectionButtonText": "Check",
       "rememberVMwareCredentials": Object {
         "isDisabled": Object {
           "VMWARE_PROVIDER_METADATA_ID": false,

--- a/src/k8s/requests/v2v/createV2VvmwareObject.js
+++ b/src/k8s/requests/v2v/createV2VvmwareObject.js
@@ -5,7 +5,7 @@ import { buildV2VVMwareObject } from '../../objects/v2v/vmware/vmWareObject';
 import { buildVMwareSecret } from '../../objects/v2v/vmware/vmWareSecret';
 
 export const createV2VvmwareObjectWithSecret = async ({ url, username, password, namespace }, { k8sCreate }) => {
-  const secretName = `temp-${getDefaultSecretName({ url, username })}-`;
+  const secretName = `${getDefaultSecretName({ url, username })}-`;
   const secret = await k8sCreate(
     SecretModel,
     buildVMwareSecret({

--- a/src/k8s/tests/request.test.js
+++ b/src/k8s/tests/request.test.js
@@ -14,7 +14,6 @@ import {
   vmSettingsContainer,
   vmSettingsContainerWindows,
   vmSettingsCustomFlavor,
-  vmSettingsImportVmwareNewConnection,
   vmSettingsPxe,
   vmSettingsUrl,
   vmSettingsUserTemplate,
@@ -23,9 +22,9 @@ import {
   rootContainerDisk,
   rootDataVolumeDisk,
 } from '../../components/Wizard/CreateVmWizard/stateUpdate/storageTabStateUpdate';
-import { k8sCreate, k8sPatch } from '../../tests/k8s';
+import { k8sCreate } from '../../tests/k8s';
 
-import { settingsValue, selectVm, selectTemplate, selectSecret } from '../selectors';
+import { settingsValue, selectVm, selectTemplate } from '../selectors';
 
 import {
   TEMPLATE_PARAM_VM_NAME,
@@ -110,15 +109,6 @@ const testContainerImage = results => {
     settingsValue(vmSettingsContainer, CONTAINER_IMAGE_KEY)
   );
   return vm;
-};
-
-const testImportSecret = results => {
-  const secret = selectSecret(results);
-  expect(secret.kind).toBe('Secret');
-  expect(secret.metadata.generateName).toBe('my.domain.com-username-'); // composed from input values
-  expect(secret.data.username).toBe('dXNlcm5hbWU='); // base64
-  expect(secret.data.password).toBe('cGFzc3dvcmQ='); // base64
-  expect(secret.data.url).toBe('bXkuZG9tYWluLmNvbQ=='); // base64
 };
 
 const everyDiskHasVolume = results => {
@@ -616,17 +606,6 @@ describe('request.js - metadata', () => {
       getName(urlTemplate),
       getNamespace(urlTemplate)
     );
-  });
-  it('Import Secret is created', async () => {
-    const results = await createVm(
-      new EnhancedK8sMethods({ k8sCreate, k8sPatch }),
-      templates,
-      vmSettingsImportVmwareNewConnection,
-      [],
-      [],
-      persistentVolumeClaims
-    );
-    testImportSecret(results);
   });
 });
 

--- a/src/selectors/v2v/selectors.js
+++ b/src/selectors/v2v/selectors.js
@@ -10,3 +10,6 @@ export const getLoadedVm = (v2vvmware, vmName) =>
   getSimpleV2vVMwareStatus(v2vvmware) === V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL
     ? getVms(v2vvmware, []).find(v => v.name === vmName && v.detail && v.detail.raw)
     : null;
+
+export const getVmwareSecretLabels = secret => get(secret, 'metadata.labels', {});
+export const getVmwareConnectionName = value => get(value, 'spec.connection');

--- a/src/utils/patches.js
+++ b/src/utils/patches.js
@@ -432,3 +432,26 @@ export const getDeviceBootOrderPatch = (vm, removedDevicePathKey, removedDeviceN
 
   return patches;
 };
+
+export const removeLabelFromVmwareSecretPatch = labelKey => {
+  const patches = [];
+  const escapedLabel = labelKey.replace('~', '~0').replace('/', '~1');
+  patches.push({
+    op: 'remove',
+    path: `/metadata/labels/${escapedLabel}`,
+  });
+
+  return patches;
+};
+
+export const addLabelToVmwareSecretPatch = labelKey => {
+  const patches = [];
+  const escapedLabel = labelKey.replace('~', '~0').replace('/', '~1');
+  patches.push({
+    op: 'add',
+    path: `/metadata/labels/${escapedLabel}`,
+    value: 'true',
+  });
+
+  return patches;
+};

--- a/src/utils/tests/patches.test.js
+++ b/src/utils/tests/patches.test.js
@@ -8,6 +8,7 @@ import {
   TEMPLATE_FLAVOR_LABEL,
   POD_NETWORK,
   DISK_PATH_KEY,
+  VCENTER_TEMPORARY_LABEL,
 } from '../../constants';
 import {
   getPxeBootPatch,
@@ -18,6 +19,8 @@ import {
   getStartStopPatch,
   getUpdateCpuMemoryPatch,
   getDeviceBootOrderPatch,
+  removeLabelFromVmwareSecretPatch,
+  addLabelToVmwareSecretPatch,
 } from '../patches';
 import { cloudInitTestVm } from '../../tests/mocks/vm/cloudInitTestVm.mock';
 import { NETWORK_TYPE_POD, NETWORK_TYPE_MULTUS } from '../../components/Wizard/CreateVmWizard/constants';
@@ -454,6 +457,27 @@ describe('patches.js tests', () => {
     patch = getStartStopPatch(vm, false);
     expect(patch).toHaveLength(1);
     comparePatch(patch[0], '/spec', { running: false });
+  });
+
+  it('removeLabelFromVmwareSecretPatch patch', () => {
+    const patch = removeLabelFromVmwareSecretPatch(VCENTER_TEMPORARY_LABEL);
+    expect(patch).toEqual([
+      {
+        op: 'remove',
+        path: '/metadata/labels/kubevirt.io~1temporary',
+      },
+    ]);
+  });
+
+  it('addLabelToVmwareSecretPatch patch', () => {
+    const patch = addLabelToVmwareSecretPatch(VCENTER_TEMPORARY_LABEL);
+    expect(patch).toEqual([
+      {
+        op: 'add',
+        path: '/metadata/labels/kubevirt.io~1temporary',
+        value: 'true',
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
This PR fixes an issue where vCenter credentials are not saved unless the create VM wizard is completed, regardless of success or failure. These changes cause the `kubevirt.io/temporary` label to be removed from the secret if the "Remember vCenter credentials" box is checked and adds the label with a value of true if the "Remember vCenter credentials" box is unchecked; however, these changes are only made if the connection check is successful.

Bug: https://bugzilla.redhat.com/1714004

Depends on: https://github.com/kubevirt/web-ui/pull/399