### PR TITLE
Use k8s generateName for migration objects

### DIFF
--- a/src/k8s/migrate.js
+++ b/src/k8s/migrate.js
@@ -9,7 +9,7 @@ class Migration {
       apiVersion: getModelApi(VirtualMachineInstanceMigrationModel),
       kind: VirtualMachineInstanceMigrationModel.kind,
       metadata: {
-        name: null,
+        generateName: null,
         namespace: null,
       },
       spec: {
@@ -19,7 +19,7 @@ class Migration {
   }
 
   setName(name) {
-    this.data.metadata.name = name;
+    this.data.metadata.generateName = name;
   }
 
   setVmi(vmi) {
@@ -32,7 +32,7 @@ class Migration {
   }
 }
 
-export const getMigrationName = vmi => prefixedId(getName(vmi), 'migration');
+export const getMigrationName = vmi => prefixedId(getName(vmi), 'migration-');
 
 export const migrate = (k8sCreate, vmi) => {
   const migration = new Migration();

--- a/src/k8s/tests/migrate.test.js
+++ b/src/k8s/tests/migrate.test.js
@@ -9,7 +9,8 @@ describe('migrate.js', () => {
     migrate(k8sCreate, blueVmi).then(migration => {
       expect(migration.apiVersion).toBe(getModelApi(VirtualMachineInstanceMigrationModel));
       expect(migration.kind).toBe(VirtualMachineInstanceMigrationModel.kind);
-      expect(migration.metadata.name).toBe(`${blueVmi.metadata.name}-migration`);
+      expect(migration.metadata.generateName).toBe(`${blueVmi.metadata.name}-migration-`);
+      expect(migration.metadata.name.startsWith(`${blueVmi.metadata.name}-migration-`)).toBeTruthy();
       expect(migration.metadata.namespace).toBe(blueVmi.metadata.namespace);
       expect(migration.spec.vmiName).toBe(blueVmi.metadata.name);
       return migration;

--- a/src/tests/k8s.js
+++ b/src/tests/k8s.js
@@ -61,7 +61,7 @@ export const k8sCreate = (model, resource) => {
   }
 
   if (resource.metadata.generateName) {
-    resource.metadata.name = `${resource.metadata.generateName}-${Math.random()
+    resource.metadata.name = `${resource.metadata.generateName}${Math.random()
       .toString(36)
       .substr(2, 5)}`;
   }


### PR DESCRIPTION
backport of https://github.com/kubevirt/web-ui-components/pull/491

https://bugzilla.redhat.com/show_bug.cgi?id=1715050