### PR TITLE
Fix save vCenter credentials functionality

### DIFF
--- a/src/components/Wizard/CreateVmWizard/initialState/providers/vmWareInitialState.js
+++ b/src/components/Wizard/CreateVmWizard/initialState/providers/vmWareInitialState.js
@@ -11,6 +11,9 @@ import {
   PROVIDER_VMWARE_VCENTER_KEY,
   PROVIDER_VMWARE_VM_KEY,
   PROVIDER_VMWARE_V2V_LAST_ERROR,
+  PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_SAVE,
 } from '../../providers/VMwareImportProvider/constants';
 import { getSimpleV2vVMwareStatus } from '../../../../../utils/status/v2vVMware/v2vVMwareStatus';
 
@@ -30,7 +33,7 @@ export const getVmWareInitialState = props => ({
   [PROVIDER_VMWARE_CHECK_CONNECTION_KEY]: {
     isDisabled: asDisabled(true, PROVIDER_VMWARE_VCENTER_KEY),
   },
-  [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: {},
+  [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: { value: true },
   [PROVIDER_VMWARE_VM_KEY]: {
     isDisabled: asDisabled(true, PROVIDER_VMWARE_VM_KEY),
   },
@@ -45,6 +48,8 @@ export const getVmWareInitialState = props => ({
 
   // simple values
   [PROVIDER_VMWARE_V2V_NAME_KEY]: null,
+  [PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY]: null,
+  [PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY]: PROVIDER_VMWARE_CHECK_CONNECTION_BTN_SAVE,
 });
 
 const titleResolver = {
@@ -52,7 +57,7 @@ const titleResolver = {
   [PROVIDER_VMWARE_HOSTNAME_KEY]: 'vCenter Hostname',
   [PROVIDER_VMWARE_USER_NAME_KEY]: 'vCenter User Name',
   [PROVIDER_VMWARE_USER_PASSWORD_KEY]: 'vCenter Password',
-  [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: 'Remember vCenter credentials',
+  [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: 'Save as New vCenter Instance',
   [PROVIDER_VMWARE_VM_KEY]: 'VM to Import',
 };
 
@@ -81,7 +86,7 @@ const helpResolver = {
   [PROVIDER_VMWARE_USER_NAME_KEY]: () => 'User name to be used for connection to a vCenter instance.',
   [PROVIDER_VMWARE_USER_PASSWORD_KEY]: () => 'User password to be used for connection to a vCenter instance.',
   [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: () =>
-    'If checked, new secret keeping connection details will be created for later use.',
+    'If checked, a new secret containing the connection details will be created for future use.',
   [PROVIDER_VMWARE_VM_KEY]: () =>
     'Select a vCenter virtual machine to import. Loading of their list might take some time. The list will be enabled for selection once data are loaded.',
 };

--- a/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/VMWareImportProvider.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/VMWareImportProvider.js
@@ -26,6 +26,7 @@ import { FormRow } from '../../../../Form/FormRow';
 import { CONNECT_TO_NEW_INSTANCE } from '../../strings';
 import {
   PROVIDER_VMWARE,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY,
   PROVIDER_VMWARE_CHECK_CONNECTION_KEY,
   PROVIDER_VMWARE_HOSTNAME_KEY,
   PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY,
@@ -197,7 +198,7 @@ export class VMWareImportProvider extends React.Component {
             disabled={isFieldDisabled(this.getField(PROVIDER_VMWARE_CHECK_CONNECTION_KEY))}
             onClick={() => this.onChange(PROVIDER_VMWARE_CHECK_CONNECTION_KEY, true)}
           >
-            Check
+            {this.getField(PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY)}
           </Button>
         </FormRow>
         <FormRow isHidden={isFieldHidden(this.getField(PROVIDER_VMWARE_STATUS_KEY))}>

--- a/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/constants.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/constants.js
@@ -7,10 +7,14 @@ export const PROVIDER_VMWARE_USER_PASSWORD_KEY = 'vmwarePassword';
 export const PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY = 'rememberVMwareCredentials';
 
 export const PROVIDER_VMWARE_CHECK_CONNECTION_KEY = 'checkConnectionButton';
+export const PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY = 'checkConnectionButtonText';
+export const PROVIDER_VMWARE_CHECK_CONNECTION_BTN_SAVE = 'Check and Save';
+export const PROVIDER_VMWARE_CHECK_CONNECTION_BTN_DONT_SAVE = 'Check';
 export const PROVIDER_VMWARE_STATUS_KEY = 'vmwareStatus';
 
 export const PROVIDER_VMWARE_VM_KEY = 'vmwareVm';
 
 export const PROVIDER_VMWARE_V2V_NAME_KEY = 'v2vVmwareName';
+export const PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY = 'newVCenterName';
 
 export const PROVIDER_VMWARE_V2V_LAST_ERROR = 'PROVIDER_VMWARE_V2V_LAST_ERROR';

--- a/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/fixtures/VMWareImportProvider.fixture.js
+++ b/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/fixtures/VMWareImportProvider.fixture.js
@@ -1,1 +1,34 @@
-// TODO: add
+import { PROVIDERS_DATA_KEY } from '../../../constants';
+import { PROVIDER_VMWARE, PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY, PROVIDER_VMWARE_STATUS_KEY } from '../constants';
+import { V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL } from '../../../../../../utils/status/v2vVMware';
+import { VMWareImportProvider } from '../VMWareImportProvider';
+
+export const vmSettingsConnectionSuccessful = {
+  [PROVIDERS_DATA_KEY]: {
+    [PROVIDER_VMWARE]: {
+      [PROVIDER_VMWARE_STATUS_KEY]: {
+        value: V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL,
+      },
+    },
+  },
+};
+
+export const vmSettingsDontSaveCredentials = {
+  [PROVIDERS_DATA_KEY]: {
+    [PROVIDER_VMWARE]: {
+      [PROVIDER_VMWARE_STATUS_KEY]: {
+        value: V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL,
+      },
+      [PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY]: {
+        value: false,
+      },
+    },
+  },
+};
+
+export default {
+  component: VMWareImportProvider,
+  props: {
+    vmSettings: vmSettingsConnectionSuccessful,
+  },
+};

--- a/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/tests/__snapshots__/VMWareImportProvider.test.js.snap
+++ b/src/components/Wizard/CreateVmWizard/providers/VMwareImportProvider/tests/__snapshots__/VMWareImportProvider.test.js.snap
@@ -956,7 +956,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
   <FormRow
     className="kubevirt-create-vm-wizard__import-vmware-password"
     controlSize={5}
-    help="If checked, new secret keeping connection details will be created for later use."
+    help="If checked, a new secret containing the connection details will be created for future use."
     id={null}
     isHidden={false}
     isRequired={false}
@@ -969,7 +969,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
     <ValidationFormRow
       className="kubevirt-create-vm-wizard__import-vmware-password"
       controlSize={5}
-      help="If checked, new secret keeping connection details will be created for later use."
+      help="If checked, a new secret containing the connection details will be created for future use."
       id={null}
       isHidden={false}
       isRequired={false}
@@ -997,7 +997,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
               className="text-right col-sm-3"
             >
               <FormControlLabel
-                help="If checked, new secret keeping connection details will be created for later use."
+                help="If checked, a new secret containing the connection details will be created for future use."
                 isRequired={false}
                 title=""
               >
@@ -1013,7 +1013,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
                 <FieldLevelHelp
                   buttonClass=""
                   className="kubevirt-form-group__field-help"
-                  content="If checked, new secret keeping connection details will be created for later use."
+                  content="If checked, a new secret containing the connection details will be created for future use."
                   placement="right"
                   rootClose={true}
                 >
@@ -1025,7 +1025,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
                         id="popover"
                         placement="right"
                       >
-                        If checked, new secret keeping connection details will be created for later use.
+                        If checked, a new secret containing the connection details will be created for future use.
                       </Popover>
                     }
                     placement="right"
@@ -1086,7 +1086,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
                 id="vcenter-remember-credentials"
                 onBlur={[Function]}
                 onChange={[Function]}
-                title="Remember vCenter credentials"
+                title="Save as New vCenter Instance"
               >
                 <Checkbox
                   bsClass="checkbox"
@@ -1112,7 +1112,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
                         onChange={[Function]}
                         type="checkbox"
                       />
-                      Remember vCenter credentials
+                      Save as New vCenter Instance
                     </label>
                   </div>
                 </Checkbox>
@@ -1206,9 +1206,7 @@ exports[`<VMWareImportProvider /> renders correctly 1`] = `
                   id="vcenter-connect"
                   onClick={[Function]}
                   type="button"
-                >
-                  Check
-                </button>
+                />
               </Button>
             </div>
           </Col>

--- a/src/components/Wizard/CreateVmWizard/stateUpdate/providers/vmWareStateUpdate.js
+++ b/src/components/Wizard/CreateVmWizard/stateUpdate/providers/vmWareStateUpdate.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, has } from 'lodash';
 
 import {
   VM_SETTINGS_TAB_KEY,
@@ -49,6 +49,10 @@ import {
   PROVIDER_VMWARE_VCENTER_KEY,
   PROVIDER_VMWARE_VM_KEY,
   PROVIDER_VMWARE_V2V_LAST_ERROR,
+  PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_SAVE,
+  PROVIDER_VMWARE_CHECK_CONNECTION_BTN_DONT_SAVE,
 } from '../../providers/VMwareImportProvider/constants';
 import { vmSettingsCreator } from '../vmSettingsTabStateUpdate';
 import {
@@ -58,7 +62,15 @@ import {
 import { requestVmDetail } from '../../../../../k8s/requests/v2v/requestVmDetail';
 import { prefilUpdateCreator } from './prefillVmStateUpdate';
 import { getSimpleV2vVMwareStatus } from '../../../../../utils/status/v2vVMware/v2vVMwareStatus';
-import { V2V_WMWARE_STATUS_ALL_OK, V2V_WMWARE_STATUS_UNKNOWN } from '../../../../../utils/status/v2vVMware';
+import {
+  V2V_WMWARE_STATUS_ALL_OK,
+  V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL,
+  V2V_WMWARE_STATUS_UNKNOWN,
+} from '../../../../../utils/status/v2vVMware';
+import { addLabelToVmwareSecretPatch, removeLabelFromVmwareSecretPatch } from '../../../../../utils';
+import { VCENTER_TEMPORARY_LABEL } from '../../../../../constants';
+import { SecretModel } from '../../../../../models';
+import { getVmwareConnectionName, getVmwareSecretLabels } from '../../../../../selectors/v2v';
 
 const { info, warn, error } = console;
 
@@ -85,6 +97,8 @@ export const getVmwareProviderStateUpdate = (prevProps, prevState, props, state,
     ...[
       secretUpdateCreator,
       secretValueUpdateCreator,
+      saveSecretUpdateCreator,
+      successfulConnectionUpdateCreator,
       checkConnectionUpdateCreator,
       vmwareNameChangedUpdateCreator,
       vmChangedUpdateCreator,
@@ -250,6 +264,49 @@ export const secretValueUpdateCreator = (prevProps, prevState, props, state, ext
   };
 };
 
+export const successfulConnectionUpdateCreator = (prevProps, prevState, props, state, extra) => {
+  const connectionStatus = getVmwareValue(state, PROVIDER_VMWARE_STATUS_KEY);
+
+  if (connectionStatus !== V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL) {
+    return null;
+  }
+
+  const vCenterName = getVmwareField(state, PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY);
+  const secret = props.vCenterSecrets.find(s => getName(s) === vCenterName);
+  const hasTempLabel = has(getVmwareSecretLabels(secret), VCENTER_TEMPORARY_LABEL);
+  const saveCredentialsRequested = getVmwareValue(state, PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY);
+
+  if (saveCredentialsRequested && hasTempLabel) {
+    const patch = removeLabelFromVmwareSecretPatch(VCENTER_TEMPORARY_LABEL);
+    props.k8sPatch(SecretModel, secret, patch).catch(err => {
+      if (!get(err, 'message').includes('Unable to remove nonexistent key')) {
+        console.error(err); // eslint-disable-line no-console
+      }
+    });
+  }
+
+  if (!saveCredentialsRequested && !hasTempLabel) {
+    const patch = addLabelToVmwareSecretPatch(VCENTER_TEMPORARY_LABEL);
+    props.k8sPatch(SecretModel, secret, patch).catch(err => console.log(err)); // eslint-disable-line no-console
+  }
+
+  return null;
+};
+
+export const saveSecretUpdateCreator = (prevProps, prevState, props, state, extra) => {
+  if (!hasVmWareSettingsValuesChanged(prevState, state, PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY)) {
+    return null;
+  }
+
+  const saveCredentialsRequested = getVmwareValue(state, PROVIDER_VMWARE_REMEMBER_PASSWORD_KEY);
+
+  return {
+    [PROVIDER_VMWARE_CHECK_CONNECTION_BTN_TEXT_KEY]: saveCredentialsRequested
+      ? PROVIDER_VMWARE_CHECK_CONNECTION_BTN_SAVE
+      : PROVIDER_VMWARE_CHECK_CONNECTION_BTN_DONT_SAVE,
+  };
+};
+
 export const checkConnectionUpdateCreator = (prevProps, prevState, props, state, extra) => {
   const oldConnect = !!getVmwareValue(prevState, PROVIDER_VMWARE_CHECK_CONNECTION_KEY);
   const connect = !!getVmwareValue(state, PROVIDER_VMWARE_CHECK_CONNECTION_KEY);
@@ -373,6 +430,7 @@ const createConnectionObjects = (props, params, { safeSetState }, afterData) => 
           value: getSimpleV2vVMwareStatus(null, { isConnecting: true }),
         },
         [PROVIDER_VMWARE_V2V_NAME_KEY]: getName(v2vVmware),
+        [PROVIDER_VMWARE_NEW_VCENTER_NAME_KEY]: getVmwareConnectionName(v2vVmware),
       })
     )
     .catch(err => {

--- a/src/components/Wizard/CreateVmWizard/tests/__snapshots__/CreateVmWizard.test.js.snap
+++ b/src/components/Wizard/CreateVmWizard/tests/__snapshots__/CreateVmWizard.test.js.snap
@@ -191,6 +191,7 @@ Object {
           "vCenterInstance": true,
         },
       },
+      "checkConnectionButtonText": "Check",
       "rememberVMwareCredentials": Object {
         "isDisabled": Object {
           "VMWARE_PROVIDER_METADATA_ID": false,

--- a/src/k8s/requests/v2v/createV2VvmwareObject.js
+++ b/src/k8s/requests/v2v/createV2VvmwareObject.js
@@ -5,7 +5,7 @@ import { buildV2VVMwareObject } from '../../objects/v2v/vmware/vmWareObject';
 import { buildVMwareSecret } from '../../objects/v2v/vmware/vmWareSecret';
 
 export const createV2VvmwareObjectWithSecret = async ({ url, username, password, namespace }, { k8sCreate }) => {
-  const secretName = `temp-${getDefaultSecretName({ url, username })}-`;
+  const secretName = `${getDefaultSecretName({ url, username })}-`;
   const secret = await k8sCreate(
     SecretModel,
     buildVMwareSecret({

--- a/src/k8s/tests/request.test.js
+++ b/src/k8s/tests/request.test.js
@@ -14,7 +14,6 @@ import {
   vmSettingsContainer,
   vmSettingsContainerWindows,
   vmSettingsCustomFlavor,
-  vmSettingsImportVmwareNewConnection,
   vmSettingsPxe,
   vmSettingsUrl,
   vmSettingsUserTemplate,
@@ -23,9 +22,9 @@ import {
   rootContainerDisk,
   rootDataVolumeDisk,
 } from '../../components/Wizard/CreateVmWizard/stateUpdate/storageTabStateUpdate';
-import { k8sCreate, k8sPatch } from '../../tests/k8s';
+import { k8sCreate } from '../../tests/k8s';
 
-import { settingsValue, selectVm, selectTemplate, selectSecret } from '../selectors';
+import { settingsValue, selectVm, selectTemplate } from '../selectors';
 
 import {
   TEMPLATE_PARAM_VM_NAME,
@@ -110,15 +109,6 @@ const testContainerImage = results => {
     settingsValue(vmSettingsContainer, CONTAINER_IMAGE_KEY)
   );
   return vm;
-};
-
-const testImportSecret = results => {
-  const secret = selectSecret(results);
-  expect(secret.kind).toBe('Secret');
-  expect(secret.metadata.generateName).toBe('my.domain.com-username-'); // composed from input values
-  expect(secret.data.username).toBe('dXNlcm5hbWU='); // base64
-  expect(secret.data.password).toBe('cGFzc3dvcmQ='); // base64
-  expect(secret.data.url).toBe('bXkuZG9tYWluLmNvbQ=='); // base64
 };
 
 const everyDiskHasVolume = results => {
@@ -616,17 +606,6 @@ describe('request.js - metadata', () => {
       getName(urlTemplate),
       getNamespace(urlTemplate)
     );
-  });
-  it('Import Secret is created', async () => {
-    const results = await createVm(
-      new EnhancedK8sMethods({ k8sCreate, k8sPatch }),
-      templates,
-      vmSettingsImportVmwareNewConnection,
-      [],
-      [],
-      persistentVolumeClaims
-    );
-    testImportSecret(results);
   });
 });
 

--- a/src/selectors/v2v/selectors.js
+++ b/src/selectors/v2v/selectors.js
@@ -10,3 +10,6 @@ export const getLoadedVm = (v2vvmware, vmName) =>
   getSimpleV2vVMwareStatus(v2vvmware) === V2V_WMWARE_STATUS_CONNECTION_SUCCESSFUL
     ? getVms(v2vvmware, []).find(v => v.name === vmName && v.detail && v.detail.raw)
     : null;
+
+export const getVmwareSecretLabels = secret => get(secret, 'metadata.labels', {});
+export const getVmwareConnectionName = value => get(value, 'spec.connection');

--- a/src/utils/patches.js
+++ b/src/utils/patches.js
@@ -432,3 +432,26 @@ export const getDeviceBootOrderPatch = (vm, removedDevicePathKey, removedDeviceN
 
   return patches;
 };
+
+export const removeLabelFromVmwareSecretPatch = labelKey => {
+  const patches = [];
+  const escapedLabel = labelKey.replace('~', '~0').replace('/', '~1');
+  patches.push({
+    op: 'remove',
+    path: `/metadata/labels/${escapedLabel}`,
+  });
+
+  return patches;
+};
+
+export const addLabelToVmwareSecretPatch = labelKey => {
+  const patches = [];
+  const escapedLabel = labelKey.replace('~', '~0').replace('/', '~1');
+  patches.push({
+    op: 'add',
+    path: `/metadata/labels/${escapedLabel}`,
+    value: 'true',
+  });
+
+  return patches;
+};

--- a/src/utils/tests/patches.test.js
+++ b/src/utils/tests/patches.test.js
@@ -8,6 +8,7 @@ import {
   TEMPLATE_FLAVOR_LABEL,
   POD_NETWORK,
   DISK_PATH_KEY,
+  VCENTER_TEMPORARY_LABEL,
 } from '../../constants';
 import {
   getPxeBootPatch,
@@ -18,6 +19,8 @@ import {
   getStartStopPatch,
   getUpdateCpuMemoryPatch,
   getDeviceBootOrderPatch,
+  removeLabelFromVmwareSecretPatch,
+  addLabelToVmwareSecretPatch,
 } from '../patches';
 import { cloudInitTestVm } from '../../tests/mocks/vm/cloudInitTestVm.mock';
 import { NETWORK_TYPE_POD, NETWORK_TYPE_MULTUS } from '../../components/Wizard/CreateVmWizard/constants';
@@ -454,6 +457,27 @@ describe('patches.js tests', () => {
     patch = getStartStopPatch(vm, false);
     expect(patch).toHaveLength(1);
     comparePatch(patch[0], '/spec', { running: false });
+  });
+
+  it('removeLabelFromVmwareSecretPatch patch', () => {
+    const patch = removeLabelFromVmwareSecretPatch(VCENTER_TEMPORARY_LABEL);
+    expect(patch).toEqual([
+      {
+        op: 'remove',
+        path: '/metadata/labels/kubevirt.io~1temporary',
+      },
+    ]);
+  });
+
+  it('addLabelToVmwareSecretPatch patch', () => {
+    const patch = addLabelToVmwareSecretPatch(VCENTER_TEMPORARY_LABEL);
+    expect(patch).toEqual([
+      {
+        op: 'add',
+        path: '/metadata/labels/kubevirt.io~1temporary',
+        value: 'true',
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
This PR fixes an issue where vCenter credentials are not saved unless the create VM wizard is completed, regardless of success or failure. These changes cause the kubevirt.io/temporary label to be removed from the secret if the "Remember vCenter credentials" box is checked and adds the label with a value of true if the "Remember vCenter credentials" box is unchecked; however, these changes are only made if the connection check is successful.

Bug: https://bugzilla.redhat.com/1714004

Depends on: kubevirt/web-ui#399

Original PR: https://github.com/kubevirt/web-ui-components/pull/489