### PR TITLE
Remove dot character from DNS-1123 validation

### DIFF
--- a/src/utils/tests/validation.test.js
+++ b/src/utils/tests/validation.test.js
@@ -60,7 +60,6 @@ describe('validation.js - validateDNS1123SubdomainValue tests', () => {
     expect(validateDNS1123SubdomainValue('abc')).toBeNull();
     expect(validateDNS1123SubdomainValue('1abc')).toBeNull();
     expect(validateDNS1123SubdomainValue('aab-c')).toBeNull();
-    expect(validateDNS1123SubdomainValue('aa.bc')).toBeNull();
     expect(validateDNS1123SubdomainValue('a'.repeat(253))).toBeNull();
   });
   it('returns warning for uppercase value', () => {
@@ -86,6 +85,7 @@ describe('validation.js - validateDNS1123SubdomainValue tests', () => {
     expect(validateDNS1123SubdomainValue('ab_c')).toEqual(getValidationObject(`${DNS1123_CONTAINS_ERROR} _`));
     expect(validateDNS1123SubdomainValue('ab/c')).toEqual(getValidationObject(`${DNS1123_CONTAINS_ERROR} /`));
     expect(validateDNS1123SubdomainValue('ab*c')).toEqual(getValidationObject(`${DNS1123_CONTAINS_ERROR} *`));
+    expect(validateDNS1123SubdomainValue('ab.c')).toEqual(getValidationObject(`${DNS1123_CONTAINS_ERROR} .`));
   });
 });
 

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -51,7 +51,7 @@ export const validateDNS1123SubdomainValue = value => {
   }
   for (let i = 1; i < value.length - 1; i++) {
     const char = value.charAt(i);
-    if (!char.match('[-a-zA-Z0-9.]')) {
+    if (!char.match('[-a-zA-Z0-9]')) {
       const offender = char.match('\\s') ? 'whitespace characters' : char;
       return getValidationObject(`${DNS1123_CONTAINS_ERROR} ${offender}`);
     }


### PR DESCRIPTION
The dot character is not allowed in a subdomain value as the dot character is the delimiter between subdomain values.