### PR TITLE
Create VM Wizard: conditionally rendered Import provision source

### DIFF
--- a/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
@@ -188,7 +188,7 @@ export class CreateVmWizard extends React.Component {
       key: VM_SETTINGS_TAB_KEY,
       onCloseWizard: onCloseVmSettings,
       render: () => {
-        const { namespaces, templates, dataVolumes, virtualMachines, Firehose } = this.props;
+        const { namespaces, templates, dataVolumes, virtualMachines, Firehose, isV2vVmwareCrd } = this.props;
 
         const loadingData = { namespaces, templates, dataVolumes, virtualMachines };
         const vmSettings = getVmSettings(this.state);
@@ -201,6 +201,7 @@ export class CreateVmWizard extends React.Component {
               vmSettings={vmSettings}
               onChange={(value, valid) => this.onStepDataChanged(VM_SETTINGS_TAB_KEY, value, valid)}
               {...loadingData}
+              isV2vVmwareCrd={isV2vVmwareCrd}
             >
               <ImportProvider isVisible={isVmwareProvider(this.state)}>
                 <Firehose resources={vmwareImportResources}>
@@ -318,6 +319,7 @@ CreateVmWizard.defaultProps = {
   storageClasses: null,
   createTemplate: false,
   dataVolumes: null,
+  isV2vVmwareCrd: false,
 };
 
 CreateVmWizard.propTypes = {
@@ -337,4 +339,5 @@ CreateVmWizard.propTypes = {
   units: PropTypes.object.isRequired,
   createTemplate: PropTypes.bool,
   dataVolumes: PropTypes.array,
+  isV2vVmwareCrd: PropTypes.bool,
 };

--- a/src/components/Wizard/CreateVmWizard/initialState/vmSettingsTabInitialState.js
+++ b/src/components/Wizard/CreateVmWizard/initialState/vmSettingsTabInitialState.js
@@ -48,8 +48,8 @@ export const getVmSettingsInitialState = props => ({
   valid: false,
 });
 
-export const getInitialVmSettings = (props = { createTemplate: false }) => {
-  const { createTemplate } = props;
+export const getInitialVmSettings = (props = { createTemplate: false, isV2vVmwareCrd: false }) => {
+  const { createTemplate, isV2vVmwareCrd } = props;
 
   const provisionSources = [
     PROVISION_SOURCE_PXE,
@@ -60,7 +60,10 @@ export const getInitialVmSettings = (props = { createTemplate: false }) => {
 
   const importProviders = createTemplate ? [] : getProviders();
 
-  if (!createTemplate) {
+  if (!createTemplate && isV2vVmwareCrd) {
+    // Conditionally-enabled providers should go one level down, means to the list of providers.
+    // But as long as there is listed just a single "VMware" provider, the top-level "Import" option
+    // is disabled if VMware provider can not be used.
     provisionSources.push(PROVISION_SOURCE_IMPORT);
   }
 


### PR DESCRIPTION
The V2V Import VMware option is supposed to be rendered just in case
that related infrastructure is deployed on the cluster.

In other words, check for presence of V2VVMware CRD is introduced.

As we have just a single provider (VMware) so far, the higher-level
"Import"-provision type is not rendered if the CRD is missing.