### PR TITLE
Use SC defaults for DV creation

### DIFF
--- a/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
@@ -145,6 +145,7 @@ export class CreateVmWizard extends React.Component {
       this.state.stepData[NETWORKS_TAB_KEY].value,
       this.state.stepData[STORAGE_TAB_KEY].value,
       this.props.persistentVolumeClaims,
+      this.props.storageClassConfigMap,
       this.props.units
     )
       .then(() => getResults(enhancedK8sMethods))
@@ -316,6 +317,7 @@ CreateVmWizard.defaultProps = {
   selectedNamespace: null,
   networkConfigs: null,
   persistentVolumeClaims: null,
+  storageClassConfigMap: null,
   storageClasses: null,
   createTemplate: false,
   dataVolumes: null,
@@ -335,6 +337,7 @@ CreateVmWizard.propTypes = {
   selectedNamespace: PropTypes.object,
   networkConfigs: PropTypes.array,
   persistentVolumeClaims: PropTypes.array,
+  storageClassConfigMap: PropTypes.object,
   storageClasses: PropTypes.array,
   units: PropTypes.object.isRequired,
   createTemplate: PropTypes.bool,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -37,6 +37,10 @@ export const PROVISION_SOURCE_CLONED_DISK = 'Cloned Disk'; // PVC or upload imag
 
 export const PVC_ACCESSMODE_RWO = 'ReadWriteOnce';
 export const PVC_ACCESSMODE_RWM = 'ReadWriteMany';
+export const PVC_ACCESSMODE_DEFAULT = PVC_ACCESSMODE_RWO;
+export const PVC_VOLUMEMODE_FS = 'Filesystem';
+export const PVC_VOLUMEMODE_BLOCK = 'Block';
+export const PVC_VOLUMEMODE_DEFAULT = PVC_VOLUMEMODE_FS;
 
 export const TEMPLATE_API_VERSION = 'template.openshift.io/v1';
 export const TEMPLATE_FLAVOR_LABEL = 'flavor.template.kubevirt.io';

--- a/src/k8s/clone.js
+++ b/src/k8s/clone.js
@@ -14,6 +14,8 @@ import {
   getDataVolumeStorageClassName,
   getOperatingSystemName,
   getOperatingSystem,
+  getPvcVolumeMode,
+  getDataVolumeMode,
 } from '../selectors';
 import { getStartStopPatch, generateDiskName } from '../utils';
 import { addDataVolumeTemplate, addTemplateLabel } from './vmBuilder';
@@ -102,6 +104,7 @@ const addDataVolumeClones = (vm, newName, dataVolumes) => {
           dvName,
           getNamespace(dataVolume),
           getDataVolumeAccessModes(dataVolume),
+          getDataVolumeMode(dataVolume),
           getDataVolumeStorageSize(dataVolume),
           getDataVolumeStorageClassName(dataVolume),
           newName
@@ -125,6 +128,7 @@ const addPvcClones = (vm, newName, persistentVolumeClaims) => {
         pvcName,
         getNamespace(pvc),
         getPvcAccessModes(pvc),
+        getPvcVolumeMode(pvc),
         getPvcStorageSize(pvc),
         getPvcStorageClassName(pvc),
         newName
@@ -136,12 +140,21 @@ const addPvcClones = (vm, newName, persistentVolumeClaims) => {
     });
 };
 
-export const addTemplateClone = (vm, pvcName, pvcNamespace, accessModes, size, storageClassName, vmName) => {
-  const template = getPvcCloneTemplate(pvcName, pvcNamespace, accessModes, size, storageClassName, vmName);
+export const addTemplateClone = (
+  vm,
+  pvcName,
+  pvcNamespace,
+  accessModes,
+  volumeMode,
+  size,
+  storageClassName,
+  vmName
+) => {
+  const template = getPvcCloneTemplate(pvcName, pvcNamespace, accessModes, volumeMode, size, storageClassName, vmName);
   return addDataVolumeTemplate(vm, template);
 };
 
-const getPvcCloneTemplate = (pvcName, pvcNamespace, accessModes, size, storageClassName, vmName) => ({
+const getPvcCloneTemplate = (pvcName, pvcNamespace, accessModes, volumeMode, size, storageClassName, vmName) => ({
   metadata: {
     name: generateDiskName(vmName, pvcName, true),
   },
@@ -154,6 +167,7 @@ const getPvcCloneTemplate = (pvcName, pvcNamespace, accessModes, size, storageCl
     },
     pvc: {
       accessModes,
+      volumeMode,
       resources: {
         requests: {
           storage: size,

--- a/src/k8s/vmBuilder.js
+++ b/src/k8s/vmBuilder.js
@@ -1,4 +1,4 @@
-import { get, last } from 'lodash';
+import { get, last, isEmpty } from 'lodash';
 
 import {
   PROVISION_SOURCE_PXE,
@@ -6,7 +6,8 @@ import {
   BOOT_ORDER_SECOND,
   DEVICE_TYPE_DISK,
   DEVICE_TYPE_INTERFACE,
-  PVC_ACCESSMODE_RWM,
+  PVC_ACCESSMODE_DEFAULT,
+  PVC_VOLUMEMODE_DEFAULT,
 } from '../constants';
 
 import {
@@ -320,7 +321,8 @@ export const getDataVolumeTemplateSpec = (storage, dvSource) => {
     },
     spec: {
       pvc: {
-        accessModes: [PVC_ACCESSMODE_RWM],
+        accessModes: isEmpty(storage.accessModes) ? [PVC_ACCESSMODE_DEFAULT] : storage.accessModes,
+        volumeMode: storage.volumeMode || PVC_VOLUMEMODE_DEFAULT,
         resources: {
           requests: {
             storage: `${storage.size}Gi`,

--- a/src/selectors/configmap/index.js
+++ b/src/selectors/configmap/index.js
@@ -1,0 +1,1 @@
+export * from './sc-defaults';

--- a/src/selectors/configmap/sc-defaults.js
+++ b/src/selectors/configmap/sc-defaults.js
@@ -1,0 +1,13 @@
+import { get } from 'lodash';
+
+import { PVC_ACCESSMODE_DEFAULT, PVC_VOLUMEMODE_DEFAULT } from '../../constants';
+
+export const getDefaultSCAccessMode = (storageClassConfigMap, scName) => {
+  const defaultAccessMode = get(storageClassConfigMap, ['data', 'accessMode'], PVC_ACCESSMODE_DEFAULT);
+  return get(storageClassConfigMap, ['data', `${scName}.accessMode`], defaultAccessMode);
+};
+
+export const getDefaultSCVolumeMode = (storageClassConfigMap, scName) => {
+  const defaultVolumeMode = get(storageClassConfigMap, ['data', 'volumeMode'], PVC_VOLUMEMODE_DEFAULT);
+  return get(storageClassConfigMap, ['data', `${scName}.volumeMode`], defaultVolumeMode);
+};

--- a/src/selectors/dv/selectors.js
+++ b/src/selectors/dv/selectors.js
@@ -11,6 +11,7 @@ import { getStorageSize } from '../common';
 export const getDataVolumeStorageSize = dataVolume => getStorageSize(getDataVolumeResources(dataVolume));
 export const getDataVolumeResources = dataVolume => get(dataVolume, 'spec.pvc.resources');
 export const getDataVolumeAccessModes = dataVolume => get(dataVolume, 'spec.pvc.accessModes');
+export const getDataVolumeMode = dataVolume => get(dataVolume, 'spec.pvc.volumeMode');
 export const getDataVolumeStorageClassName = dataVolume => get(dataVolume, 'spec.pvc.storageClassName');
 
 export const getDataVolumeSourceType = dataVolume => {

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -11,5 +11,5 @@ export * from './pvc';
 export * from './vm';
 export * from './vmi';
 export * from './service';
-
+export * from './configmap';
 export * from './prometheus';

--- a/src/selectors/pvc/selectors.js
+++ b/src/selectors/pvc/selectors.js
@@ -11,4 +11,5 @@ export const getPvcStorageSize = pvc => getStorageSize(getPvcResources(pvc));
 
 export const getPvcResources = pvc => get(pvc, 'spec.resources');
 export const getPvcAccessModes = pvc => get(pvc, 'spec.accessModes');
+export const getPvcVolumeMode = pvc => get(pvc, 'spec.volumeMode');
 export const getPvcStorageClassName = pvc => get(pvc, 'spec.storageClassName');


### PR DESCRIPTION
The `kubevirt-storage-class-defaults` ConfigMap is read for `accessMode` and `volumeMode` defaults when creating a DataVolume.

Sibling PR: https://github.com/openshift/console/pull/2200

ConfigMap example:
```
kind: ConfigMap
apiVersion: v1
metadata:
  # well-known name
  name: kubevirt-storage-class-defaults
  namespace: openshift
data:
    # The default if a StorageClass is not listed.
    # If these ultimate defaults are missing or the ConfigMap is inaccessible, these
    # defaults are hard-coded in the UI as well.
  accessMode: ReadWriteOnce
  volumeMode: Filesystem
  local-sc.accessMode: ReadWriteOnce
  local-sc.volumeMode: Filesystem
  nfs-sc.accessMode: ReadWriteMany
  nfs-sc.volumeMode: Filesystem
```