### PR TITLE
v2v: move v2v-vmware ConfigMap to kubevirt-hyperconverged namespace

### DIFF
--- a/src/k8s/requests/v2v/constants.js
+++ b/src/k8s/requests/v2v/constants.js
@@ -8,7 +8,7 @@ export const CONVERSION_PROGRESS_ANNOTATION = 'v2vConversionProgress';
 
 export const V2VVMWARE_DEPLOYMENT_NAME = 'v2v-vmware';
 
-export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACE = 'openshift'; // along the common-templates ...
+export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACE = 'kubevirt-hyperconverged';
 export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME = 'v2v-vmware';
 
 export const VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAMESPACE = 'kube-public'; // note: common-templates are in the "openshift" namespace


### PR DESCRIPTION
More safe to avoid unrelated modifications.

Follow-up for #507 