### PR TITLE
Deploy VDDK as side-car container

### DIFF
--- a/src/components/Wizard/CreateVmWizard/StorageTab.js
+++ b/src/components/Wizard/CreateVmWizard/StorageTab.js
@@ -18,7 +18,6 @@ import {
   STORAGE_TYPE_CONTAINER,
   STORAGE_TYPE_EXTERNAL_IMPORT,
   STORAGE_TYPE_EXTERNAL_V2V_TEMP,
-  STORAGE_TYPE_EXTERNAL_V2V_VDDK,
 } from './constants';
 
 import {
@@ -83,7 +82,6 @@ const validateContainerStorage = storage => genericValidator(storage, [nameValid
 const validateExternalImportStorage = storage => genericValidator(storage, [nameValidation, positiveSizeValidation]);
 const validateExternalTempImportStorage = storage =>
   genericValidator(storage, [nameValidation, positiveSizeValidation]);
-const validateExternalVddkImportStorage = storage => genericValidator(storage, [nameValidation]);
 
 const validateResolver = {
   [STORAGE_TYPE_PVC]: validatePvcStorage,
@@ -91,7 +89,6 @@ const validateResolver = {
   [STORAGE_TYPE_CONTAINER]: validateContainerStorage,
   [STORAGE_TYPE_EXTERNAL_IMPORT]: validateExternalImportStorage,
   [STORAGE_TYPE_EXTERNAL_V2V_TEMP]: validateExternalTempImportStorage,
-  [STORAGE_TYPE_EXTERNAL_V2V_VDDK]: validateExternalVddkImportStorage,
 };
 
 const validateStorage = row => {
@@ -238,7 +235,6 @@ const resolveInitialStorages = (
         case STORAGE_TYPE_DATAVOLUME:
         case STORAGE_TYPE_EXTERNAL_IMPORT:
         case STORAGE_TYPE_EXTERNAL_V2V_TEMP:
-        case STORAGE_TYPE_EXTERNAL_V2V_VDDK:
           result = {
             ...result,
             ...storage,
@@ -405,7 +401,7 @@ export class StorageTab extends React.Component {
             initialValue: '--- Select Storage ---',
           };
         }
-        if ([STORAGE_TYPE_EXTERNAL_V2V_TEMP, STORAGE_TYPE_EXTERNAL_V2V_VDDK].includes(storage.storageType)) {
+        if (STORAGE_TYPE_EXTERNAL_V2V_TEMP === storage.storageType) {
           return null;
         }
         return {
@@ -480,9 +476,7 @@ export class StorageTab extends React.Component {
       type: ACTIONS_TYPE,
       renderEditConfig: storage =>
         storage.rootStorage ||
-        [STORAGE_TYPE_EXTERNAL_IMPORT, STORAGE_TYPE_EXTERNAL_V2V_TEMP, STORAGE_TYPE_EXTERNAL_V2V_VDDK].includes(
-          storage.storageType
-        )
+        [STORAGE_TYPE_EXTERNAL_IMPORT, STORAGE_TYPE_EXTERNAL_V2V_TEMP].includes(storage.storageType)
           ? null
           : {
               id: 'actions',

--- a/src/components/Wizard/CreateVmWizard/constants.js
+++ b/src/components/Wizard/CreateVmWizard/constants.js
@@ -38,7 +38,6 @@ export const STORAGE_TYPE_PVC = 'pvc';
 export const STORAGE_TYPE_DATAVOLUME = 'datavolume';
 export const STORAGE_TYPE_EXTERNAL_IMPORT = 'external-import';
 export const STORAGE_TYPE_EXTERNAL_V2V_TEMP = 'external-v2v-temp';
-export const STORAGE_TYPE_EXTERNAL_V2V_VDDK = 'external-v2v-vddk';
 export const STORAGE_TYPE_CONTAINER = 'container';
 export const DATA_VOLUME_SOURCE_BLANK = 'datavolume-blank';
 export const DATA_VOLUME_SOURCE_URL = 'datavolume-url';

--- a/src/components/Wizard/CreateVmWizard/stateUpdate/providers/prefillVmStateUpdate.js
+++ b/src/components/Wizard/CreateVmWizard/stateUpdate/providers/prefillVmStateUpdate.js
@@ -11,13 +11,12 @@ import {
   STORAGE_TAB_KEY,
   STORAGE_TYPE_EXTERNAL_IMPORT,
   STORAGE_TYPE_EXTERNAL_V2V_TEMP,
-  STORAGE_TYPE_EXTERNAL_V2V_VDDK,
   VM_SETTINGS_TAB_KEY,
 } from '../../constants';
 import { getVmwareAttribute } from '../../providers/VMwareImportProvider/selectors';
 import { getVmSettingAttribute } from '../../utils/vmSettingsTabUtils';
 import { PROVIDER_VMWARE_VM_KEY } from '../../providers/VMwareImportProvider/constants';
-import { CONVERSION_POD_TEMP_MOUNT_PATH, CONVERSION_POD_VDDK_MOUNT_PATH } from '../../../../../k8s/requests/v2v';
+import { CONVERSION_POD_TEMP_MOUNT_PATH } from '../../../../../k8s/requests/v2v';
 import { CUSTOM_FLAVOR } from '../../../../../constants';
 
 /**
@@ -133,19 +132,6 @@ export const getDisks = parsedVm => {
     storageClass: undefined,
     data: {
       mountPath: CONVERSION_POD_TEMP_MOUNT_PATH,
-    },
-  });
-
-  // TODO: make vddk configurable or move setup to somewhere else
-  // vddk pvc must be present in the same namespace as the VM
-  diskRows.push({
-    editable: false,
-    id: diskRows.length,
-    storageType: STORAGE_TYPE_EXTERNAL_V2V_VDDK,
-    name: 'vddk-pvc',
-    storageClass: undefined,
-    data: {
-      mountPath: CONVERSION_POD_VDDK_MOUNT_PATH,
     },
   });
 

--- a/src/k8s/objects/v2v/vmware/conversionPod.js
+++ b/src/k8s/objects/v2v/vmware/conversionPod.js
@@ -2,8 +2,9 @@ import { PodModel } from '../../../../models';
 import {
   CONVERSION_BASE_NAME,
   CONVERSION_GENERATE_NAME,
-  VMWARE_VDDK_INIT,
-  VMWARE_VOLUME_VDDK,
+  CONVERSION_VDDK_INIT_POD_NAME,
+  CONVERSION_VOLUME_VDDK_NAME,
+  CONVERSION_VDDK_MOUNT_PATH,
 } from '../../../requests/v2v';
 
 export const buildConversionPod = ({
@@ -27,12 +28,12 @@ export const buildConversionPod = ({
 
     initContainers: [
       {
-        name: VMWARE_VDDK_INIT,
+        name: CONVERSION_VDDK_INIT_POD_NAME,
         image: vddkInitImage,
         volumeMounts: [
           {
-            name: VMWARE_VOLUME_VDDK,
-            mountPath: '/opt/vmware-vix-disklib-distrib',
+            name: CONVERSION_VOLUME_VDDK_NAME,
+            mountPath: CONVERSION_VDDK_MOUNT_PATH,
           },
         ],
       },
@@ -56,8 +57,8 @@ export const buildConversionPod = ({
             mountPath: '/dev/kvm',
           },
           {
-            name: VMWARE_VOLUME_VDDK,
-            mountPath: '/opt/vmware-vix-disklib-distrib',
+            name: CONVERSION_VOLUME_VDDK_NAME,
+            mountPath: CONVERSION_VDDK_MOUNT_PATH,
           },
           ...volumeMounts,
         ],
@@ -77,7 +78,7 @@ export const buildConversionPod = ({
         },
       },
       {
-        name: VMWARE_VOLUME_VDDK,
+        name: CONVERSION_VOLUME_VDDK_NAME,
         emptyDir: {},
       },
       ...volumes,

--- a/src/k8s/objects/v2v/vmware/conversionPod.js
+++ b/src/k8s/objects/v2v/vmware/conversionPod.js
@@ -1,5 +1,10 @@
 import { PodModel } from '../../../../models';
-import { CONVERSION_BASE_NAME, CONVERSION_GENERATE_NAME } from '../../../requests/v2v';
+import {
+  CONVERSION_BASE_NAME,
+  CONVERSION_GENERATE_NAME,
+  VMWARE_VDDK_INIT,
+  VMWARE_VOLUME_VDDK,
+} from '../../../requests/v2v';
 
 export const buildConversionPod = ({
   volumes,
@@ -9,6 +14,7 @@ export const buildConversionPod = ({
   secretName,
   imagePullPolicy,
   image,
+  vddkInitImage,
 }) => ({
   apiVersion: PodModel.apiVersion,
   kind: PodModel.kind,
@@ -18,6 +24,20 @@ export const buildConversionPod = ({
   },
   spec: {
     serviceAccountName,
+
+    initContainers: [
+      {
+        name: VMWARE_VDDK_INIT,
+        image: vddkInitImage,
+        volumeMounts: [
+          {
+            name: VMWARE_VOLUME_VDDK,
+            mountPath: '/opt/vmware-vix-disklib-distrib',
+          },
+        ],
+      },
+    ],
+
     containers: [
       {
         name: CONVERSION_BASE_NAME,
@@ -35,6 +55,10 @@ export const buildConversionPod = ({
             name: 'kvm',
             mountPath: '/dev/kvm',
           },
+          {
+            name: VMWARE_VOLUME_VDDK,
+            mountPath: '/opt/vmware-vix-disklib-distrib',
+          },
           ...volumeMounts,
         ],
       },
@@ -51,6 +75,10 @@ export const buildConversionPod = ({
         hostPath: {
           path: '/dev/kvm',
         },
+      },
+      {
+        name: VMWARE_VOLUME_VDDK,
+        emptyDir: {},
       },
       ...volumes,
     ],

--- a/src/k8s/request.js
+++ b/src/k8s/request.js
@@ -64,7 +64,6 @@ import {
   STORAGE_TYPE_DATAVOLUME,
   STORAGE_TYPE_EXTERNAL_IMPORT,
   STORAGE_TYPE_EXTERNAL_V2V_TEMP,
-  STORAGE_TYPE_EXTERNAL_V2V_VDDK,
   STORAGE_TYPE_PVC,
   USE_CLOUD_INIT_CUSTOM_SCRIPT_KEY,
   USER_TEMPLATE_KEY,
@@ -446,9 +445,7 @@ const addStorages = (vm, template, storages, getSetting, persistentVolumeClaims,
 
   if (storages) {
     storages
-      .filter(
-        storage => ![STORAGE_TYPE_EXTERNAL_V2V_TEMP, STORAGE_TYPE_EXTERNAL_V2V_VDDK].includes(storage.storageType)
-      )
+      .filter(storage => STORAGE_TYPE_EXTERNAL_V2V_TEMP !== storage.storageType)
       .forEach(storage => {
         switch (storage.storageType) {
           case STORAGE_TYPE_PVC:

--- a/src/k8s/requests/v2v/constants.js
+++ b/src/k8s/requests/v2v/constants.js
@@ -16,3 +16,6 @@ export const VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAMESPACE = 'kube-public'; // note
 export const VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAME = 'vmware-to-kubevirt-os'; // single configMap per cluster, contains mapping of vmware guestId to common-templates OS ID
 
 export const CONVERSION_SERVICEACCOUNT_DELAY = 2 * 1000; // in ms
+
+export const VMWARE_VDDK_INIT = 'vddk-init';
+export const VMWARE_VOLUME_VDDK = 'volume-vddk';

--- a/src/k8s/requests/v2v/constants.js
+++ b/src/k8s/requests/v2v/constants.js
@@ -1,5 +1,4 @@
 export const CONVERSION_POD_TEMP_MOUNT_PATH = '/var/tmp';
-export const CONVERSION_POD_VDDK_MOUNT_PATH = '/data/vddklib'; // will be /data/vddklib/vmware-vix-disklib-distrib
 
 export const CONVERSION_BASE_NAME = 'kubevirt-v2v-conversion';
 export const CONVERSION_GENERATE_NAME = `${CONVERSION_BASE_NAME}-`;
@@ -17,5 +16,6 @@ export const VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAME = 'vmware-to-kubevirt-os'; //
 
 export const CONVERSION_SERVICEACCOUNT_DELAY = 2 * 1000; // in ms
 
-export const VMWARE_VDDK_INIT = 'vddk-init';
-export const VMWARE_VOLUME_VDDK = 'volume-vddk';
+export const CONVERSION_VDDK_INIT_POD_NAME = 'vddk-init';
+export const CONVERSION_VOLUME_VDDK_NAME = 'volume-vddk';
+export const CONVERSION_VDDK_MOUNT_PATH = '/opt/vmware-vix-disklib-distrib';

--- a/src/k8s/requests/v2v/importVmware.js
+++ b/src/k8s/requests/v2v/importVmware.js
@@ -40,7 +40,11 @@ import {
   getVmwareField,
 } from '../../../components/Wizard/CreateVmWizard/providers/VMwareImportProvider/selectors';
 import { getValidK8SSize, delay } from '../../../utils';
-import { getV2vImagePullPolicy, getKubevirtV2vConversionContainerImage } from '../../../selectors/v2v';
+import {
+  getV2vImagePullPolicy,
+  getKubevirtV2vConversionContainerImage,
+  getVddkInitContainerImage,
+} from '../../../selectors/v2v';
 import { getServiceAccountSecrets } from '../../../selectors/serviceaccount/serviceaccount';
 
 const asVolumenMount = ({ name, storageType, data }) => ({
@@ -231,6 +235,7 @@ const startConversionPod = async (
       secretName: getName(conversionPodSecret),
       imagePullPolicy: getV2vImagePullPolicy(kubevirtVmwareConfigMap),
       image: getKubevirtV2vConversionContainerImage(kubevirtVmwareConfigMap),
+      vddkInitImage: getVddkInitContainerImage(kubevirtVmwareConfigMap),
     })
   );
 

--- a/src/k8s/requests/v2v/importVmware.js
+++ b/src/k8s/requests/v2v/importVmware.js
@@ -14,7 +14,6 @@ import {
   NAMESPACE_KEY,
   STORAGE_TYPE_EXTERNAL_IMPORT,
   STORAGE_TYPE_EXTERNAL_V2V_TEMP,
-  STORAGE_TYPE_EXTERNAL_V2V_VDDK,
 } from '../../../components/Wizard/CreateVmWizard/constants';
 import { getName, getNamespace } from '../../../selectors';
 import { buildConversionPod, buildConversionPodSecret, buildV2VRole } from '../../objects/v2v';
@@ -207,11 +206,7 @@ const startConversionPod = async (
   const volumeMounts = [];
 
   mappedStorages
-    .filter(({ storageType }) =>
-      [STORAGE_TYPE_EXTERNAL_IMPORT, STORAGE_TYPE_EXTERNAL_V2V_TEMP, STORAGE_TYPE_EXTERNAL_V2V_VDDK].includes(
-        storageType
-      )
-    )
+    .filter(({ storageType }) => [STORAGE_TYPE_EXTERNAL_IMPORT, STORAGE_TYPE_EXTERNAL_V2V_TEMP].includes(storageType))
     .forEach(storage => {
       volumeMounts.push(asVolumenMount(storage));
       volumes.push(asVolume(storage));

--- a/src/selectors/v2v/selectors.js
+++ b/src/selectors/v2v/selectors.js
@@ -32,6 +32,13 @@ export const getKubevirtV2vVmwareContainerImage = kubevirtVmwareConfigMap =>
     `kubevirt-vmware-image is missing in the ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} ConfigMap`
   );
 
+export const getVddkInitContainerImage = kubevirtVmwareConfigMap =>
+  get(
+    kubevirtVmwareConfigMap,
+    ['data', 'vddk-init-image'],
+    `vddk-init-image is missing in the ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} ConfigMap`
+  );
+
 // optional param in the ConfigMap
 export const getV2vImagePullPolicy = kubevirtVmwareConfigMap =>
   get(kubevirtVmwareConfigMap, ['data', 'kubevirt-vmware-image-pull-policy'], 'IfNotPresent');


### PR DESCRIPTION
The `v2v-vmware` ConfigMap is extended for new `vddk-init-image` key referring image built by cluster user/admin for the [VMware VDDK library](https://www.vmware.com/support/developer/vddk/) based on instructions in Kubevirt's documentation.

The image is used for a side-car container providing the library to the conversion pod,
replacing former vddk-pvc created once per-namespace.

---
- once per cluster, create a `vddk-init` container image, see instructions in https://github.com/oVirt/v2v-conversion-host/commit/bf8bd0a91c3ad67f285c55fe831105c29647db45
- `oc edit configmap v2v-vmware -n kubevirt-hyperconverged`
  - under `data:` section, add new entry based on the first step above:
    ```
    vddk-init-image: your.registry/vddk-init:latest
    ```

Please note, initial version of the `v2v-vmware` ConfigMap in the `kubevirt-hyperconverged` namespace referenced in the instructions above will be created automatically by `v2v operator` which is under development at the time of writing this pull request. It's content can be found i.e. in #532.
