### PR TITLE
Default to ReadWriteMany

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -39,7 +39,7 @@ export const PROVISION_SOURCE_UNKNOWN_DATAVOLUME_SOURCE = 'Unknown DataVolume So
 
 export const PVC_ACCESSMODE_RWO = 'ReadWriteOnce';
 export const PVC_ACCESSMODE_RWM = 'ReadWriteMany';
-export const PVC_ACCESSMODE_DEFAULT = PVC_ACCESSMODE_RWO;
+export const PVC_ACCESSMODE_DEFAULT = PVC_ACCESSMODE_RWM;
 export const PVC_VOLUMEMODE_FS = 'Filesystem';
 export const PVC_VOLUMEMODE_BLOCK = 'Block';
 export const PVC_VOLUMEMODE_DEFAULT = PVC_VOLUMEMODE_FS;


### PR DESCRIPTION
In https://github.com/kubevirt/web-ui-components/pull/528 we changed the default PVC access mode from `PVC_ACCESSMODE_RWM` to `PVC_ACCESSMODE_DEFAULT` [1] that is `PVC_ACCESSMODE_RWO` [2]

If we run a VM create wizard that leave the PVC access mode `undefined` the VM will fail because the correct default value is `PVC_ACCESSMODE_RWM` and not `PVC_ACCESSMODE_RWO`.

This will fail the e2e tests.

Refs:
[1] https://github.com/kubevirt/web-ui-components/pull/528/files#diff-4f2c25e67b23719f1195914b33c45601R324
[2] https://github.com/kubevirt/web-ui-components/pull/528/files#diff-bc152a022be0db29b061aedc08d80a45R40