### PR TITLE
Enable close button on failed VM creation in Wizard

### DIFF
--- a/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
@@ -301,7 +301,7 @@ export class CreateVmWizard extends React.Component {
         previousStepDisabled={currentStepData.lockStep ? true : lastStepReached}
         cancelButtonDisabled={lastStepReached}
         stepButtonsDisabled={lastStepReached}
-        nextStepDisabled={currentStepData.lockStep ? true : !currentStepData.valid}
+        nextStepDisabled={currentStepData.lockStep ? true : !currentStepData.valid && !lastStepReached}
         nextText={beforeLastStepReached ? createVmText : NEXT}
         title={createVmText}
         dialogClassName="modal-lg wizard-pf kubevirt-wizard kubevirt-create-vm-wizard"


### PR DESCRIPTION
This PR enables the "Close" button in the create VM wizard regardless of whether creation succeeded or failed.

Bug: https://bugzilla.redhat.com/1721454