### PR TITLE
Fix cluster & storage overview snapshots

### DIFF
--- a/src/components/BareMetalHosts/tests/BaremetalHostStatus.test.js
+++ b/src/components/BareMetalHosts/tests/BaremetalHostStatus.test.js
@@ -9,7 +9,9 @@ const getComponentFunction = props => () => <BaremetalHostStatus {...props} />;
 
 describe('<BaremetalHostStatus />', () => {
   BaremetalHostStatusFixture.forEach((fixture, index) => {
-    it(`renders the correct subcomponent for the "${fixture.props.host.status.provisioning.state}" state (${index})`, () => {
+    it(`renders the correct subcomponent for the "${
+      fixture.props.host.status.provisioning.state
+    }" state (${index})`, () => {
       const component = shallow(getComponentFunction(fixture.props)());
       expect(component).toMatchSnapshot();
     });

--- a/src/components/ClusterOverview/tests/__snapshots__/ClusterOverview.test.js.snap
+++ b/src/components/ClusterOverview/tests/__snapshots__/ClusterOverview.test.js.snap
@@ -17,7 +17,7 @@ exports[`<ClusterOverview /> renders correctly 1`] = `
       <MediaQuery
         key="main-medium"
         maxWidth={991.9}
-        values={null}
+        values={Object {}}
       >
         <MainCards />
       </MediaQuery>
@@ -25,7 +25,7 @@ exports[`<ClusterOverview /> renders correctly 1`] = `
       <MediaQuery
         key="main-large"
         minWidth={992}
-        values={null}
+        values={Object {}}
       >
         <MainCards />
       </MediaQuery>

--- a/src/components/StorageOverview/tests/__snapshots__/StorageOverview.test.js.snap
+++ b/src/components/StorageOverview/tests/__snapshots__/StorageOverview.test.js.snap
@@ -17,7 +17,7 @@ exports[`<StorageOverview /> shallow-renders correctly 1`] = `
       <MediaQuery
         key="main-medium"
         maxWidth={991.9}
-        values={null}
+        values={Object {}}
       >
         <MainCards />
       </MediaQuery>
@@ -25,7 +25,7 @@ exports[`<StorageOverview /> shallow-renders correctly 1`] = `
       <MediaQuery
         key="main-large"
         minWidth={992}
-        values={null}
+        values={Object {}}
       >
         <MainCards />
       </MediaQuery>


### PR DESCRIPTION
This PR updates Jest snapshots and formatting from changes made in https://github.com/kubevirt/web-ui-components/pull/536 that were causing test failures.