### PR TITLE
Validate hostname in cloud-init settings

### DIFF
--- a/src/components/Wizard/CreateVmWizard/tests/__snapshots__/CreateVmWizard.test.js.snap
+++ b/src/components/Wizard/CreateVmWizard/tests/__snapshots__/CreateVmWizard.test.js.snap
@@ -71,6 +71,7 @@ Object {
       "cloudInit": true,
       "useCloudInitCustomScript": false,
     },
+    "validation": null,
     "value": null,
   },
   "imageURL": Object {

--- a/src/components/Wizard/CreateVmWizard/validations/vmSettingsTabValidation.js
+++ b/src/components/Wizard/CreateVmWizard/validations/vmSettingsTabValidation.js
@@ -8,6 +8,7 @@ import {
   validateURL,
   validateMemory,
   validateUserTemplate,
+  validateCloudInitHostName,
 } from '../../../../utils/validations';
 import { objectMerge } from '../../../../utils/utils';
 import { settingsValue } from '../../../../k8s/selectors';
@@ -22,6 +23,7 @@ import {
   PROVISION_SOURCE_TYPE_KEY,
   MEMORY_KEY,
   USER_TEMPLATE_KEY,
+  HOST_NAME_KEY,
 } from '../constants';
 import { NAMESPACE_MUST_BE_SELECTED } from '../../../../utils/strings';
 import { isProviderValid, validateProvider } from '../providers';
@@ -51,6 +53,7 @@ const validateResolver = {
   [IMAGE_URL_KEY]: asVmSettingsValidator(validateURL),
   [PROVIDER_KEY]: validateProviderDropdown,
   [MEMORY_KEY]: asVmSettingsValidator(validateMemory),
+  [HOST_NAME_KEY]: asVmSettingsValidator(validateCloudInitHostName),
 };
 
 export const validateVmSettings = (vmSettings, additionalResources) => {

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -123,6 +123,11 @@ export const validateVmLikeEntityName = (value, vmSettings, props) => {
       );
 };
 
+export const validateCloudInitHostName = value => {
+  const dnsValidation = validateDNS1123SubdomainValue(value);
+  return dnsValidation && dnsValidation.isEmptyError ? null : dnsValidation;
+};
+
 export const validateUserTemplate = (userTemplateKey, vmSettings, props) => {
   const userTemplateName = get(vmSettings, [userTemplateKey, 'value']);
   const userTemplate =


### PR DESCRIPTION
This PR adds hostname validation to the cloud-init settings section of the create VM/template wizard.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1648321