### PR TITLE
Namespaces for kubevirt-storage-class-defaults and v2v-vmware

### DIFF
--- a/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
+++ b/src/components/Wizard/CreateVmWizard/CreateVmWizard.js
@@ -145,7 +145,6 @@ export class CreateVmWizard extends React.Component {
       this.state.stepData[NETWORKS_TAB_KEY].value,
       this.state.stepData[STORAGE_TAB_KEY].value,
       this.props.persistentVolumeClaims,
-      this.props.storageClassConfigMap,
       this.props.units
     )
       .then(() => getResults(enhancedK8sMethods))
@@ -318,7 +317,6 @@ CreateVmWizard.defaultProps = {
   selectedNamespace: null,
   networkConfigs: null,
   persistentVolumeClaims: null,
-  storageClassConfigMap: null,
   storageClasses: null,
   createTemplate: false,
   dataVolumes: null,
@@ -339,7 +337,6 @@ CreateVmWizard.propTypes = {
   selectedNamespace: PropTypes.object,
   networkConfigs: PropTypes.array,
   persistentVolumeClaims: PropTypes.array,
-  storageClassConfigMap: PropTypes.object,
   storageClasses: PropTypes.array,
   units: PropTypes.object.isRequired,
   createTemplate: PropTypes.bool,

--- a/src/k8s/request.js
+++ b/src/k8s/request.js
@@ -106,6 +106,7 @@ import {
 import { importVmwareVm } from './requests/v2v';
 import { buildAddOwnerReferencesPatch, buildOwnerReference } from './util/utils';
 import { isVmwareProvider } from '../components/Wizard/CreateVmWizard/providers/VMwareImportProvider/selectors';
+import { getStorageClassConfigMap } from './requests';
 
 export * from './requests/hosts';
 
@@ -116,13 +117,12 @@ const FALLBACK_DISK = {
 };
 
 export const createVmTemplate = async (
-  { k8sCreate, getActualState },
+  { k8sGet, k8sCreate, getActualState },
   templates,
   vmSettings,
   networks,
   storage,
-  persistentVolumeClaims,
-  storageClassConfigMap
+  persistentVolumeClaims
 ) => {
   const getSetting = param => {
     switch (param) {
@@ -134,6 +134,9 @@ export const createVmTemplate = async (
         return settingsValue(vmSettings, param);
     }
   };
+
+  const storageClassConfigMap = await getStorageClassConfigMap({ k8sGet });
+
   const template = getModifiedVmTemplate(
     templates,
     vmSettings,
@@ -198,7 +201,6 @@ export const createVm = async (
   networks,
   storages,
   persistentVolumeClaims,
-  storageClassConfigMap,
   units
 ) => {
   const getSetting = settingsValue.bind(undefined, vmSettings);
@@ -223,6 +225,8 @@ export const createVm = async (
     conversionPod = importResult.conversionPod;
     storages = importResult.mappedStorages;
   }
+
+  const storageClassConfigMap = await getStorageClassConfigMap({ k8sGet });
 
   const template = getModifiedVmTemplate(
     templates,

--- a/src/k8s/requests/index.js
+++ b/src/k8s/requests/index.js
@@ -1,2 +1,3 @@
 export * from './hosts';
 export * from './v2v';
+export * from './storageClass';

--- a/src/k8s/requests/storageClass/constants.js
+++ b/src/k8s/requests/storageClass/constants.js
@@ -1,0 +1,3 @@
+export const STORAGE_CLASS_CONFIG_MAP_NAME = 'kubevirt-storage-class-defaults';
+// Different releases, different locations. Respect the order when resolving. Otherwise the configMap name/namespace is considered as well-known.
+export const STORAGE_CLASS_CONFIG_MAP_NAMESPACES = ['openshift-cnv', 'openshift'];

--- a/src/k8s/requests/storageClass/index.js
+++ b/src/k8s/requests/storageClass/index.js
@@ -1,0 +1,1 @@
+export * from './storageClassConfigMap';

--- a/src/k8s/requests/storageClass/storageClassConfigMap.js
+++ b/src/k8s/requests/storageClass/storageClassConfigMap.js
@@ -8,7 +8,7 @@ const getStorageClassConfigMapInNamespace = async ({ k8sGet, namespace }) => {
     return await k8sGet(ConfigMapModel, STORAGE_CLASS_CONFIG_MAP_NAME, namespace, null, { disableHistory: true });
   } catch (e) {
     info(
-      `The ${STORAGE_CLASS_CONFIG_MAP_NAME} can not be found in the ${namespace} namespace. Trying another in one ... Error: `,
+      `The ${STORAGE_CLASS_CONFIG_MAP_NAME} can not be found in the ${namespace} namespace. Another namespace will be queried, if any left. Error: `,
       e
     );
   }

--- a/src/k8s/requests/storageClass/storageClassConfigMap.js
+++ b/src/k8s/requests/storageClass/storageClassConfigMap.js
@@ -1,0 +1,36 @@
+import { STORAGE_CLASS_CONFIG_MAP_NAME, STORAGE_CLASS_CONFIG_MAP_NAMESPACES } from './constants';
+import { ConfigMapModel } from '../../../models';
+
+const { info, warn } = console;
+
+const getStorageClassConfigMapInNamespace = async ({ k8sGet, namespace }) => {
+  try {
+    return await k8sGet(ConfigMapModel, STORAGE_CLASS_CONFIG_MAP_NAME, namespace, null, { disableHistory: true });
+  } catch (e) {
+    info(
+      `The ${STORAGE_CLASS_CONFIG_MAP_NAME} can not be found in the ${namespace} namespace. Trying another in one ... Error: `,
+      e
+    );
+  }
+  return null;
+};
+
+export const getStorageClassConfigMap = async props => {
+  // query namespaces sequentially to respect order
+  for (let index = 0; index < STORAGE_CLASS_CONFIG_MAP_NAMESPACES.length; index++) {
+    // eslint-disable-next-line no-await-in-loop
+    const configMap = await getStorageClassConfigMapInNamespace({
+      namespace: STORAGE_CLASS_CONFIG_MAP_NAMESPACES[index],
+      ...props,
+    });
+    if (configMap) {
+      return configMap;
+    }
+  }
+  warn(
+    `The ${STORAGE_CLASS_CONFIG_MAP_NAME} can not be found in none of following namespaces: `,
+    JSON.stringify(STORAGE_CLASS_CONFIG_MAP_NAMESPACES),
+    '. The PVCs will be created with default values.'
+  );
+  return null;
+};

--- a/src/k8s/requests/v2v/constants.js
+++ b/src/k8s/requests/v2v/constants.js
@@ -7,8 +7,9 @@ export const CONVERSION_PROGRESS_ANNOTATION = 'v2vConversionProgress';
 
 export const V2VVMWARE_DEPLOYMENT_NAME = 'v2v-vmware';
 
-export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACE = 'kubevirt-hyperconverged';
 export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME = 'v2v-vmware';
+// Different releases, different locations. Respect the order when resolving. Otherwise the configMap name/namespace is considered as well-known.
+export const VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES = ['openshift-cnv', 'kubevirt-hyperconverged'];
 
 export const VMWARE_TO_KUBEVIRT_OS_CONFIG_MAP_NAMESPACE = 'kube-public'; // note: common-templates are in the "openshift" namespace
 // TODO: make it configurable via VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP

--- a/src/k8s/requests/v2v/importVmware.js
+++ b/src/k8s/requests/v2v/importVmware.js
@@ -8,7 +8,6 @@ import {
   RoleModel,
   SecretModel,
   ServiceAccountModel,
-  ConfigMapModel,
 } from '../../../models';
 import {
   NAMESPACE_KEY,
@@ -18,12 +17,7 @@ import {
 import { getName, getNamespace } from '../../../selectors';
 import { buildConversionPod, buildConversionPodSecret, buildV2VRole } from '../../objects/v2v';
 import { buildPvc, buildServiceAccount, buildServiceAccountRoleBinding } from '../../objects';
-import {
-  CONVERSION_GENERATE_NAME,
-  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME,
-  VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACE,
-  CONVERSION_SERVICEACCOUNT_DELAY,
-} from './constants';
+import { CONVERSION_GENERATE_NAME, CONVERSION_SERVICEACCOUNT_DELAY } from './constants';
 import { buildOwnerReference, buildAddOwnerReferencesPatch } from '../../util/utils';
 import {
   PROVIDER_VMWARE_HOSTNAME_KEY,
@@ -45,6 +39,7 @@ import {
   getVddkInitContainerImage,
 } from '../../../selectors/v2v';
 import { getServiceAccountSecrets } from '../../../selectors/serviceaccount/serviceaccount';
+import { getVmwareConfigMap } from './vmwareConfigMap';
 
 const asVolumenMount = ({ name, storageType, data }) => ({
   name,
@@ -212,11 +207,7 @@ const startConversionPod = async (
       volumes.push(asVolume(storage));
     });
 
-  const kubevirtVmwareConfigMap = await k8sGet(
-    ConfigMapModel,
-    VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME,
-    VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACE
-  );
+  const kubevirtVmwareConfigMap = getVmwareConfigMap({ k8sGet });
 
   await waitForServiceAccountSecrets(serviceAccount, { k8sGet });
 

--- a/src/k8s/requests/v2v/vmwareConfigMap.js
+++ b/src/k8s/requests/v2v/vmwareConfigMap.js
@@ -1,0 +1,40 @@
+import { VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES, VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME } from './constants';
+import { ConfigMapModel } from '../../../models';
+
+const { info, warn } = console;
+
+const getVmwareConfigMapInNamespace = async ({ k8sGet, namespace }) => {
+  try {
+    return await k8sGet(ConfigMapModel, VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME, namespace, null, {
+      disableHistory: true,
+    });
+  } catch (e) {
+    // This ConfigMap is expected to be created by a v2v operator which is currecntly under development.
+    // In the meantime, see https://github.com/kubevirt/web-ui-components/pull/507 for example.
+    info(
+      `The ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} can not be found in the ${namespace} namespace. Trying another in one ... Error: `,
+      e
+    );
+  }
+  return null;
+};
+
+export const getVmwareConfigMap = async props => {
+  // query namespaces sequentially to respect order
+  for (let index = 0; index < VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES.length; index++) {
+    // eslint-disable-next-line no-await-in-loop
+    const configMap = await getVmwareConfigMapInNamespace({
+      namespace: VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES[index],
+      ...props,
+    });
+    if (configMap) {
+      return configMap;
+    }
+  }
+  warn(
+    `The ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} can not be found in none of following namespaces: `,
+    JSON.stringify(VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES),
+    '. The v2v pods can not be created.'
+  );
+  return null;
+};

--- a/src/k8s/requests/v2v/vmwareConfigMap.js
+++ b/src/k8s/requests/v2v/vmwareConfigMap.js
@@ -9,8 +9,6 @@ const getVmwareConfigMapInNamespace = async ({ k8sGet, namespace }) => {
       disableHistory: true,
     });
   } catch (e) {
-    // This ConfigMap is expected to be created by a v2v operator which is currecntly under development.
-    // In the meantime, see https://github.com/kubevirt/web-ui-components/pull/507 for example.
     info(
       `The ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} can not be found in the ${namespace} namespace. Trying another in one ... Error: `,
       e
@@ -19,6 +17,8 @@ const getVmwareConfigMapInNamespace = async ({ k8sGet, namespace }) => {
   return null;
 };
 
+// The "v2v-vmware" ConfigMap is expected to be created by a v2v operator which is currecntly under development.
+// In the meantime, see https://github.com/kubevirt/web-ui-components/pull/507 for example.
 export const getVmwareConfigMap = async props => {
   // query namespaces sequentially to respect order
   for (let index = 0; index < VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAMESPACES.length; index++) {

--- a/src/k8s/requests/v2v/vmwareConfigMap.js
+++ b/src/k8s/requests/v2v/vmwareConfigMap.js
@@ -10,7 +10,7 @@ const getVmwareConfigMapInNamespace = async ({ k8sGet, namespace }) => {
     });
   } catch (e) {
     info(
-      `The ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} can not be found in the ${namespace} namespace. Trying another in one ... Error: `,
+      `The ${VMWARE_KUBEVIRT_VMWARE_CONFIG_MAP_NAME} can not be found in the ${namespace} namespace.  Another namespace will be queried, if any left. Error: `,
       e
     );
   }


### PR DESCRIPTION
Fixes issue with changing location of ConfigMaps in different releases.

The `kubevirt-storage-class-defaults` ConfigMap is attempted to be retrieved from the `openshift-cnv` first, then from `openshift` in case of error.

The `v2v-vmware` ConfigMap is read from `openshift-cnv` namespace first, then from `kubevirt-hyperconverged`.