### PR TITLE
Enhance getVmiIpAddresses() function

### DIFF
--- a/src/selectors/vmi/selectors.js
+++ b/src/selectors/vmi/selectors.js
@@ -1,13 +1,25 @@
-import { get } from 'lodash';
+import { get, uniq, flatMap } from 'lodash';
 
 export const isVmiRunning = vmi => get(vmi, 'status.phase') === 'Running';
 
 export const getVmiIpAddresses = vmi =>
-  get(vmi, 'status.interfaces', [])
-    // get IPs only for named interfaces because Windows reports IPs for other devices like Loopback Pseudo-Interface 1 etc.
-    .filter(i => i.name)
-    .map(i => i.ipAddress)
-    .filter(ip => ip && ip.trim().length > 0);
+  uniq(
+    flatMap(
+      // get IPs only for named interfaces because Windows reports IPs for other devices like Loopback Pseudo-Interface 1 etc.
+      get(vmi, 'status.interfaces', []).filter(i => i.name),
+      i => {
+        const arr = [];
+        if (i.ipAddress) {
+          // the "ipAddress" is deprecated but still can contain useful value
+          arr.push(i.ipAddress.trim());
+        }
+        if (i.ipAddresses && Array.isArray(i.ipAddresses) && i.ipAddresses.length > 0) {
+          arr.push(...i.ipAddresses.map(ip => ip.trim()));
+        }
+        return arr;
+      }
+    ).filter(ip => ip && ip.length > 0)
+  );
 
 export const getHostname = vmi => get(vmi, 'spec.hostname');
 


### PR DESCRIPTION
Enhanced to deal with both `ipAddress` and `ipAddresses`,
children of `vmi.status.interfaces`.

More info: https://kubevirt.io/api-reference/master/definitions.html#_v1_virtualmachineinstancenetworkinterface