### PR TITLE
export v2v request functions + few fixes

### DIFF
--- a/src/k8s/index.js
+++ b/src/k8s/index.js
@@ -1,5 +1,6 @@
 export * from './request';
 export * from './requests/storageClass';
+export * from './requests/v2v';
 export * from './selectors';
 
 export { getBootableDevicesInOrder } from './vmBuilder';

--- a/src/k8s/requests/v2v/correctVCenterSecretLabels.js
+++ b/src/k8s/requests/v2v/correctVCenterSecretLabels.js
@@ -11,7 +11,13 @@ export const correctVCenterSecretLabels = async ({ secret, saveCredentialsReques
 
     if (saveCredentialsRequested && hasTempLabel) {
       const patch = removeLabelFromVmwareSecretPatch(VCENTER_TEMPORARY_LABEL);
-      return k8sPatch(SecretModel, secret, patch).catch(err => {
+      return k8sPatch(SecretModel, secret, [
+        patch,
+        {
+          op: 'remove',
+          path: `/metadata/ownerReferences`,
+        },
+      ]).catch(err => {
         if (!get(err, 'message').includes('Unable to remove nonexistent key')) {
           console.error(err); // eslint-disable-line no-console
         }

--- a/src/k8s/requests/v2v/createV2VvmwareObject.js
+++ b/src/k8s/requests/v2v/createV2VvmwareObject.js
@@ -3,8 +3,12 @@ import { getName } from '../../../selectors';
 import { getDefaultSecretName } from './utils';
 import { buildV2VVMwareObject } from '../../objects/v2v/vmware/vmWareObject';
 import { buildVMwareSecret } from '../../objects/v2v/vmware/vmWareSecret';
+import { buildAddOwnerReferencesPatch, buildOwnerReference } from '../../util';
 
-export const createV2VvmwareObjectWithSecret = async ({ url, username, password, namespace }, { k8sCreate }) => {
+export const createV2VvmwareObjectWithSecret = async (
+  { url, username, password, namespace },
+  { k8sCreate, k8sPatch }
+) => {
   const secretName = `${getDefaultSecretName({ url, username })}-`;
   const secret = await k8sCreate(
     SecretModel,
@@ -18,7 +22,7 @@ export const createV2VvmwareObjectWithSecret = async ({ url, username, password,
     })
   );
 
-  return k8sCreate(
+  const v2vvmware = await k8sCreate(
     V2VVMwareModel,
     buildV2VVMwareObject({
       generateName: `check-${getDefaultSecretName({ url, username })}-`,
@@ -27,6 +31,14 @@ export const createV2VvmwareObjectWithSecret = async ({ url, username, password,
       isTemporary: true, // remove this object automatically (by controller)
     })
   );
+
+  if (v2vvmware) {
+    const newOwnerReferences = [buildOwnerReference(v2vvmware)];
+    const patches = [buildAddOwnerReferencesPatch(secret, newOwnerReferences)];
+    await k8sPatch(SecretModel, secret, patches);
+  }
+
+  return v2vvmware;
 };
 
 // ATM, Kubernetes does not support deletion of CRs with a gracefulPeriod (delayed deletion).

--- a/src/k8s/requests/v2v/index.js
+++ b/src/k8s/requests/v2v/index.js
@@ -1,3 +1,6 @@
+export * from './correctVCenterSecretLabels';
+export * from './createV2VvmwareObject';
 export * from './importVmware';
+export * from './requestVmDetail';
 export * from './startV2VvmwareController';
 export * from './constants';

--- a/src/k8s/requests/v2v/startV2VvmwareController.js
+++ b/src/k8s/requests/v2v/startV2VvmwareController.js
@@ -51,16 +51,13 @@ export const startV2VVMWareController = async ({ namespace }, { k8sGet, k8sCreat
     }
   } catch (e) {
     // Deployment does not exist or does not have permissions to see Deployments in this namespace
-    // TODO: notify the user in other way not just the console.log
     info(
       e && e.message === OLD_VERSION
         ? 'updating V2V VMWare controller'
         : 'V2V VMWare controller deployment not found, so creating one ...'
     );
 
-    // TODO: do not fail if i.e. ServiceAccount already exists
-    // TODO: notify user if deployment fails
-    [cleanupOldDeployment, resolveRolesAndServiceAccount, startVmWare].reduce(
+    await [cleanupOldDeployment, resolveRolesAndServiceAccount, startVmWare].reduce(
       async (lastResultPromise, stepFunction) => {
         const lastResult = await lastResultPromise;
         const nextResult = await stepFunction(lastResult, {


### PR DESCRIPTION
- add secret owner references
- move selectors for clearer approach
- support unit when creating PVCs
- let startV2VVMWareController behave like a promise

required by https://github.com/openshift/console/pull/2964