### PR TITLE
add default value to getsettings

### DIFF
--- a/src/k8s/request.js
+++ b/src/k8s/request.js
@@ -124,14 +124,14 @@ export const createVmTemplate = async (
   storage,
   persistentVolumeClaims
 ) => {
-  const getSetting = param => {
+  const getSetting = (param, defaultValue) => {
     switch (param) {
       case NAME_KEY:
         return `\${${TEMPLATE_PARAM_VM_NAME}}`;
       case DESCRIPTION_KEY:
         return undefined;
       default:
-        return settingsValue(vmSettings, param);
+        return settingsValue(vmSettings, param, defaultValue);
     }
   };
 


### PR DESCRIPTION
Add a default value to the `getSetting` method used in `createVmTemplate` to make it similar to the `getSetting` method used in `createVM`

See discussion here:
https://github.com/openshift/console/pull/3355#pullrequestreview-315615211